### PR TITLE
Support configuration property with relaxed names

### DIFF
--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.rocketmq.nameServer=localhost:9876
+spring.rocketmq.name-server=localhost:9876
 spring.rocketmq.producer.group=my-group1
 spring.rocketmq.topic=string-topic
 spring.rocketmq.orderTopic=order-paid-topic

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/config/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/config/RocketMQAutoConfiguration.java
@@ -38,18 +38,18 @@ import java.util.Objects;
 
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
-@ConditionalOnProperty(prefix = "spring.rocketmq", value = "nameServer")
+@ConditionalOnProperty(prefix = "spring.rocketmq", value = "name-server")
 @Import(ListenerContainerConfiguration.class)
 public class RocketMQAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean(DefaultMQProducer.class)
-    @ConditionalOnProperty(prefix = "spring.rocketmq", value = {"nameServer", "producer.group"})
+    @ConditionalOnProperty(prefix = "spring.rocketmq", value = {"name-server", "producer.group"})
     public DefaultMQProducer defaultMQProducer(RocketMQProperties rocketMQProperties) {
         RocketMQProperties.Producer producerConfig = rocketMQProperties.getProducer();
         String nameServer = rocketMQProperties.getNameServer();
         String groupName = producerConfig.getGroup();
-        Assert.hasText(nameServer, "[spring.rocketmq.nameServer] must not be null");
+        Assert.hasText(nameServer, "[spring.rocketmq.name-server] must not be null");
         Assert.hasText(groupName, "[spring.rocketmq.producer.group] must not be null");
 
         DefaultMQProducer producer = new DefaultMQProducer(groupName);
@@ -98,7 +98,8 @@ public class RocketMQAutoConfiguration {
     @Bean(name = RocketMQConfigUtils.ROCKETMQ_TRANSACTION_ANNOTATION_PROCESSOR_BEAN_NAME)
     @ConditionalOnBean(TransactionHandlerRegistry.class)
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
-    public static RocketMQTransactionAnnotationProcessor transactionAnnotationProcessor(TransactionHandlerRegistry transactionHandlerRegistry) {
+    public static RocketMQTransactionAnnotationProcessor transactionAnnotationProcessor(
+        TransactionHandlerRegistry transactionHandlerRegistry) {
         return new RocketMQTransactionAnnotationProcessor(transactionHandlerRegistry);
     }
 }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/config/RocketMQAutoConfigurationTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/config/RocketMQAutoConfigurationTest.java
@@ -48,8 +48,8 @@ public class RocketMQAutoConfigurationTest {
 
 
     @Test
-    public void testDefaultMQProducer() {
-        runner.withPropertyValues("spring.rocketmq.nameServer=127.0.0.1:9876",
+    public void testDefaultMQProducerWithRelaxPropertyName() {
+        runner.withPropertyValues("spring.rocketmq.name-server=127.0.0.1:9876",
                 "spring.rocketmq.producer.group=spring_rocketmq").
                 run((context) -> {
                     assertThat(context).hasSingleBean(DefaultMQProducer.class);
@@ -59,8 +59,18 @@ public class RocketMQAutoConfigurationTest {
     }
 
     @Test
+    public void testDefaultMQProducer() {
+        runner.withPropertyValues("spring.rocketmq.nameServer=127.0.0.1:9876",
+            "spring.rocketmq.producer.group=spring_rocketmq").
+            run((context) -> {
+                assertThat(context).hasSingleBean(DefaultMQProducer.class);
+            });
+
+    }
+
+    @Test
     public void testRocketMQListenerContainer() {
-        runner.withPropertyValues("spring.rocketmq.nameServer=127.0.0.1:9876").
+        runner.withPropertyValues("spring.rocketmq.name-server=127.0.0.1:9876").
             withUserConfiguration(TestConfig.class).
             run((context) -> {
                 // No producer on consume side


### PR DESCRIPTION
## What is the purpose of the change

Support relaxed name for autoconfigure properties:
e.g.
spring.rocketmq.name-server=
spring.rocketmq.name_server=
spring.rocketmq.nameServer=
spring.rocketmq.NAME_SERVER= 

## Brief changelog

XX

## Verifying this change

see the related UnitTest

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
