### PR TITLE
Enhance consumer classes so that consumer classes can be inherited

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -348,7 +348,13 @@ public class DefaultRocketMQListenerContainer implements InitializingBean, Rocke
     }
 
     private Class getMessageType() {
-        Type[] interfaces = AopUtils.getTargetClass(rocketMQListener).getGenericInterfaces();
+        Class<?> targetClass = AopUtils.getTargetClass(rocketMQListener);
+        Type[] interfaces = targetClass.getGenericInterfaces();
+        Class<?> superclass = targetClass.getSuperclass();
+        while ((Objects.isNull(interfaces) || 0 == interfaces.length) && Objects.nonNull(superclass)) {
+            interfaces = superclass.getGenericInterfaces();
+            superclass = targetClass.getSuperclass();
+        }
         if (Objects.nonNull(interfaces)) {
             for (Type type : interfaces) {
                 if (type instanceof ParameterizedType) {

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.junit.Test;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import static org.assertj.core.api.Assertions.assertThat;
+public class DefaultRocketMQListenerContainerTest {
+    @Test
+    public void testGetMessageType() throws NoSuchMethodException {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+        Method getMessageType = DefaultRocketMQListenerContainer.class.getDeclaredMethod("getMessageType");
+        getMessageType.setAccessible(true);
+        try {
+            listenerContainer.setRocketMQListener(new BaseStringConsumer());
+            Class result = (Class) getMessageType.invoke(listenerContainer);
+            assertThat(result.getName().equals(String.class.getName())).isTrue();
+            listenerContainer.setRocketMQListener(new BaseMessageExtConsumer());
+            result = (Class) getMessageType.invoke(listenerContainer);
+            assertThat(result.getName().equals(MessageExt.class.getName())).isTrue();
+            listenerContainer.setRocketMQListener(new ConcreteStringConsumer());
+            result = (Class) getMessageType.invoke(listenerContainer);
+            assertThat(result.getName().equals(String.class.getName())).isTrue();
+            listenerContainer.setRocketMQListener(new ConcreteMessageExtConsumer());
+            result = (Class) getMessageType.invoke(listenerContainer);
+            assertThat(result.getName().equals(MessageExt.class.getName())).isTrue();
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+    }
+}
+class BaseStringConsumer implements RocketMQListener<String> {
+    @Override
+    public void onMessage(String message) {
+    }
+}
+class ConcreteStringConsumer extends BaseStringConsumer {
+}
+class BaseMessageExtConsumer implements RocketMQListener<MessageExt> {
+    @Override
+    public void onMessage(MessageExt message) {
+    }
+}
+class ConcreteMessageExtConsumer extends BaseMessageExtConsumer {
+}


### PR DESCRIPTION
Fixed #10 

This pr is migrated from here https://github.com/apache/rocketmq-externals/pull/174

## What is the purpose of the change

Enhance consumer classes so that consumer classes can be inherited

## Brief changelog

Look for the RocketMQListener interface from the current class, if not found then look up from the parent class until it is found

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
