### PR TITLE
 但未设置mq 服务器时候，应该报错，而不是让其正常运行起来。

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -41,7 +41,6 @@ import org.springframework.util.Assert;
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
 @ConditionalOnClass({ MQAdmin.class, ObjectMapper.class })
-@ConditionalOnProperty(prefix = "rocketmq", value = "name-server")
 @Import({ JacksonFallbackConfiguration.class, ListenerContainerConfiguration.class })
 @AutoConfigureAfter(JacksonAutoConfiguration.class)
 public class RocketMQAutoConfiguration {


### PR DESCRIPTION
但未设置mq 服务器时候，应该报错，而不是让其正常运行起来。

容易造成mq 未正常接收，日志中还看不出任何问题