### PR TITLE
[ISSUE-46] Support mutliple RocketMQTemplate & name-server overrided Consumer Listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,5 +361,45 @@ public class MyConsumer implements RocketMQListener<String> {
 
 
 1. How do I send transactional messages?
-   It needs two steps on client side: a) Define a class which is annotated with @RocketMQTransactionListener and implements RocketMQLocalTransactionListener interface, in which, the executeLocalTransaction() and checkLocalTransaction() methods are implemented;
+   It needs two steps on client side: 
+   
+   a) Define a class which is annotated with @RocketMQTransactionListener and implements RocketMQLocalTransactionListener interface, in which, the executeLocalTransaction() and checkLocalTransaction() methods are implemented;
+   
    b) Invoke the sendMessageInTransaction() method with the RocketMQTemplate API. Note: The first parameter of this method is correlated with the txProducerGroup attribute of @RocketMQTransactionListener. It can be null if using the default transaction producer group.
+
+1. How do I create more than one RocketMQTemplate with a different name-server or other specific properties?
+    ```java
+    // Step1. Define an extra RocketMQTemplate with required properties, note, the 'nameServer' property must be different from the value of global
+    // Spring configuration 'rocketmq.name-server', other properties are optionally defined, they will use the global configuration 
+    // definition by default.  
+ 
+    // The RocketMQTemplate's Spring Bean name is 'extRocketMQTemplate', same with the simplified class name (Initials lowercase)
+    @ExtRocketMQTemplateConfiguration(nameServer="127.0.0.1:9876"
+       , ... // override other specific properties if needed
+    )
+    public class ExtRocketMQTemplate extends RocketMQTemplate {
+      // keep the body empty
+    }
+ 
+ 
+    // Step2. Use the extra RocketMQTemplate. e.g.
+    @Resource(name = "extRocketMQTemplate") // Must define the name to qualify to extra-defined RocketMQTemplate bean.
+    private RocketMQTemplate extRocketMQTemplate; 
+    // you can use the template as normal.
+    
+    ```
+ 
+1. How do I create a consumer Listener with different name-server other than the global Spring configuration 'rocketmq.name-server' ?  
+    ```java
+    @Service
+    @RocketMQMessageListener(
+       nameServer = "NEW-NAMESERVER-LIST", // define new nameServer list
+       topic = "test-topic-1", 
+       consumerGroup = "my-consumer_test-topic-1",
+       enableMsgTrace = true,
+       customizedTraceTopic = "my-trace-topic"
+    )
+    public class MyNameServerConsumer implements RocketMQListener<String> {
+       ...
+    }
+    ```  

--- a/rocketmq-spring-boot-samples/pom.xml
+++ b/rocketmq-spring-boot-samples/pom.xml
@@ -36,7 +36,7 @@
     </modules>
 
     <properties>
-        <rocketmq-spring-boot-starter-version>2.0.1</rocketmq-spring-boot-starter-version>
+        <rocketmq-spring-boot-starter-version>2.0.3-SNAPSHOT</rocketmq-spring-boot-starter-version>
     </properties>
 
     <dependencies>

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/consumer/StringConsumerNewNS.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/consumer/StringConsumerNewNS.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.samples.springboot.consumer;
+
+import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.springframework.stereotype.Service;
+
+/**
+ * RocketMQMessageListener
+ */
+@Service
+@RocketMQMessageListener(nameServer = "${demo.rocketmq.myNameServer}", topic = "${demo.rocketmq.topic}", consumerGroup = "string_consumer")
+public class StringConsumerNewNS implements RocketMQListener<String> {
+    @Override
+    public void onMessage(String message) {
+        System.out.printf("------- StringConsumer received: %s \n", message);
+    }
+}

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/consumer/StringConsumerNewNS.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/consumer/StringConsumerNewNS.java
@@ -29,6 +29,6 @@ import org.springframework.stereotype.Service;
 public class StringConsumerNewNS implements RocketMQListener<String> {
     @Override
     public void onMessage(String message) {
-        System.out.printf("------- StringConsumer received: %s \n", message);
+        System.out.printf("------- StringConsumerNewNS received: %s \n", message);
     }
 }

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=rocketmq-consume-demo
 
-rocketmq.name-server=11.239.187.178:9876
+rocketmq.name-server=localhost:9876
 
 # properties used in application code
 demo.rocketmq.topic=string-topic
@@ -9,4 +9,4 @@ demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
 
 # another nameserver different global
-demo.rocketmq.myNameServer=m178:9876
+demo.rocketmq.myNameServer=127.0.0.1:9876

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
@@ -1,12 +1,12 @@
 spring.application.name=rocketmq-consume-demo
 
-rocketmq.name-server=localhost:9876
-rocketmq.topic=string-topic
+rocketmq.name-server=11.239.187.178:9876
 
 # properties used in application code
+demo.rocketmq.topic=string-topic
 demo.rocketmq.orderTopic=order-paid-topic
 demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
 
 # another nameserver different global
-demo.rocketmq.myNameServer=127.0.0.1:9876
+demo.rocketmq.myNameServer=m178:9876

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
@@ -7,3 +7,6 @@ rocketmq.topic=string-topic
 demo.rocketmq.orderTopic=order-paid-topic
 demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
+
+# another nameserver different global
+demo.rocketmq.myNameServer=127.0.0.1:9876

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/java/org/apache/rocketmq/samples/springboot/ExtRocketMQTemplate.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/java/org/apache/rocketmq/samples/springboot/ExtRocketMQTemplate.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.samples.springboot;
+
+import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+
+@ExtRocketMQTemplateConfiguration(nameServer = "${demo.rocketmq.extNameServer}")
+public class ExtRocketMQTemplate extends RocketMQTemplate {
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/java/org/apache/rocketmq/samples/springboot/ProducerApplication.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/java/org/apache/rocketmq/samples/springboot/ProducerApplication.java
@@ -54,6 +54,8 @@ public class ProducerApplication implements CommandLineRunner {
     private String orderPaidTopic;
     @Value("${demo.rocketmq.msgExtTopic}")
     private String msgExtTopic;
+    @Resource(name = "extRocketMQTemplate")
+    private RocketMQTemplate extRocketMQTemplate;
 
     public static void main(String[] args) {
         SpringApplication.run(ProducerApplication.class, args);
@@ -64,6 +66,10 @@ public class ProducerApplication implements CommandLineRunner {
         // Send string
         SendResult sendResult = rocketMQTemplate.syncSend(springTopic, "Hello, World!");
         System.out.printf("syncSend1 to topic %s sendResult=%s %n", springTopic, sendResult);
+
+        // Use the extRocketMQTemplate
+        sendResult = extRocketMQTemplate.syncSend(springTopic, "Hello, World!");
+        System.out.printf("extRocketMQTemplate.syncSend1 to topic %s sendResult=%s %n", springTopic, sendResult);
 
         // Send string with spring Message
         sendResult = rocketMQTemplate.syncSend(springTopic, MessageBuilder.withPayload("Hello, World! I'm from spring message").build());

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
@@ -6,3 +6,5 @@ demo.rocketmq.topic=string-topic
 demo.rocketmq.orderTopic=order-paid-topic
 demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
+
+demo.rocketmq.extNameServer=127.0.0.1:9876

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
@@ -1,5 +1,6 @@
-rocketmq.name-server=localhost:9876
+rocketmq.name-server=11.239.187.178:9876
 rocketmq.producer.group=my-group1
+rocketmq.producer.sendMessageTimeout=300000
 
 # properties used in the application
 demo.rocketmq.topic=string-topic
@@ -7,4 +8,4 @@ demo.rocketmq.orderTopic=order-paid-topic
 demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
 
-demo.rocketmq.extNameServer=127.0.0.1:9876
+demo.rocketmq.extNameServer=m178:9876

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-rocketmq.name-server=11.239.187.178:9876
+rocketmq.name-server=localhost:9876
 rocketmq.producer.group=my-group1
 rocketmq.producer.sendMessageTimeout=300000
 
@@ -8,4 +8,4 @@ demo.rocketmq.orderTopic=order-paid-topic
 demo.rocketmq.msgExtTopic=message-ext-topic
 demo.rocketmq.transTopic=spring-transaction-topic
 
-demo.rocketmq.extNameServer=m178:9876
+demo.rocketmq.extNameServer=127.0.0.1:9876

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQTemplateConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQTemplateConfiguration.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ExtRocketMQTemplateConfiguration {
+    /**
+     * The component name of the Producer configuration.
+     */
+    String value() default "";
+
+    /**
+     * The property of "name-server".
+     */
+    String nameServer();
+
+    /**
+     * Name of producer.
+     */
+    String group() default "${rocketmq.producer.group:}";
+    /**
+     * Millis of send message timeout.
+     */
+    int sendMessageTimeout() default -1;
+    /**
+     * Compress message body threshold, namely, message body larger than 4k will be compressed on default.
+     */
+    int compressMessageBodyThreshold() default -1;
+    /**
+     * Maximum number of retry to perform internally before claiming sending failure in synchronous mode.
+     * This may potentially cause message duplication which is up to application developers to resolve.
+     */
+    int retryTimesWhenSendFailed() default -1;
+    /**
+     * <p> Maximum number of retry to perform internally before claiming sending failure in asynchronous mode. </p>
+     * This may potentially cause message duplication which is up to application developers to resolve.
+     */
+    int retryTimesWhenSendAsyncFailed() default -1;
+    /**
+     * Indicate whether to retry another broker on sending failure internally.
+     */
+    boolean retryNextServer() default false;
+    /**
+     * Maximum allowed message size in bytes.
+     */
+    int maxMessageSize() default -1;
+    /**
+     * The property of "access-key".
+     */
+    String accessKey() default "${rocketmq.producer.accessKey:}";
+    /**
+     * The property of "secret-key".
+     */
+    String secretKey() default "${rocketmq.producer.secretKey:}";
+    /**
+     * Switch flag instance for message trace.
+     */
+    boolean enableMsgTrace() default true;
+    /**
+     * The name value of message trace topic.If you don't config,you can use the default trace topic name.
+     */
+    String customizedTraceTopic() default "${rocketmq.producer.customized-trace-topic:}";
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -75,6 +75,11 @@ public @interface RocketMQMessageListener {
     int consumeThreadMax() default 64;
 
     /**
+     * Max consumer timeout, default 30s.
+     */
+    long consumeTimeout() default 30000L;
+
+    /**
      * The property of "access-key".
      */
     String accessKey() default ACCESS_KEY_PLACEHOLDER;

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
 @Documented
 public @interface RocketMQMessageListener {
 
+    String NAME_SERVER_PLACEHOLDER = "${rocketmq.name-server:}";
     String ACCESS_KEY_PLACEHOLDER = "${rocketmq.consumer.access-key:}";
     String SECRET_KEY_PLACEHOLDER = "${rocketmq.consumer.secret-key:}";
     String TRACE_TOPIC_PLACEHOLDER = "${rocketmq.consumer.customized-trace-topic:}";
@@ -93,4 +94,8 @@ public @interface RocketMQMessageListener {
      */
     String customizedTraceTopic() default TRACE_TOPIC_PLACEHOLDER;
 
+    /**
+     * The property of "name-server".
+     */
+    String nameServer() default NAME_SERVER_PLACEHOLDER;
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.autoconfigure;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.rocketmq.acl.common.AclClientRPCHook;
+import org.apache.rocketmq.acl.common.SessionCredentials;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.support.BeanDefinitionValidationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+import java.util.Objects;
+
+
+@Configuration
+public class ExtProducerResetConfiguration implements ApplicationContextAware, SmartInitializingSingleton {
+    private final static Logger log = LoggerFactory.getLogger(ExtProducerResetConfiguration.class);
+
+    private ConfigurableApplicationContext applicationContext;
+
+    private StandardEnvironment environment;
+
+    private RocketMQProperties rocketMQProperties;
+
+    private ObjectMapper objectMapper;
+
+    public ExtProducerResetConfiguration(ObjectMapper rocketMQMessageObjectMapper,
+                                             StandardEnvironment environment,
+                                             RocketMQProperties rocketMQProperties) {
+        this.objectMapper = rocketMQMessageObjectMapper;
+        this.environment = environment;
+        this.rocketMQProperties = rocketMQProperties;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        Map<String, Object> beans = this.applicationContext.getBeansWithAnnotation(ExtRocketMQTemplateConfiguration.class);
+
+        if (Objects.nonNull(beans)) {
+            beans.forEach(this::registerTemplate);
+        }
+    }
+
+    private void registerTemplate(String beanName, Object bean) {
+        Class<?> clazz = AopProxyUtils.ultimateTargetClass(bean);
+
+        if (!RocketMQTemplate.class.isAssignableFrom(bean.getClass())) {
+            throw new IllegalStateException(clazz + " is not instance of " + RocketMQTemplate.class.getName());
+        }
+
+        ExtRocketMQTemplateConfiguration annotation = clazz.getAnnotation(ExtRocketMQTemplateConfiguration.class);
+        GenericApplicationContext genericApplicationContext = (GenericApplicationContext) applicationContext;
+        validate(annotation, genericApplicationContext);
+
+        DefaultMQProducer mqProducer = createProducer(annotation);
+        // Set instanceName same as the beanName
+        mqProducer.setInstanceName(beanName);
+        try {
+            mqProducer.start();
+        } catch (MQClientException e) {
+            throw new BeanDefinitionValidationException(String.format("Failed to startup MQProducer for RocketMQTemplate {}",
+                    beanName), e);
+        }
+        RocketMQTemplate rocketMQTemplate = (RocketMQTemplate) bean;
+        rocketMQTemplate.setProducer(mqProducer);
+        rocketMQTemplate.setObjectMapper(objectMapper);
+
+
+        log.info("Set real producer to :{} {}", beanName, annotation.value());
+    }
+
+    private DefaultMQProducer createProducer(ExtRocketMQTemplateConfiguration annotation) {
+        DefaultMQProducer producer = null;
+
+        RocketMQProperties.Producer producerConfig = rocketMQProperties.getProducer();
+        if (producerConfig == null) {
+            producerConfig = new RocketMQProperties.Producer();
+        }
+        String nameServer = environment.resolvePlaceholders(annotation.nameServer());
+        String groupName = environment.resolvePlaceholders(annotation.group());
+        groupName = StringUtils.isEmpty(groupName) ? producerConfig.getGroup() : groupName;
+
+        String ak = environment.resolvePlaceholders(annotation.accessKey());
+        ak = StringUtils.isEmpty(ak) ? producerConfig.getAccessKey() : annotation.accessKey();
+        String sk = environment.resolvePlaceholders(annotation.secretKey());
+        sk = StringUtils.isEmpty(sk) ? producerConfig.getSecretKey() : annotation.secretKey();
+        String customizedTraceTopic = environment.resolvePlaceholders(annotation.customizedTraceTopic());
+        customizedTraceTopic = StringUtils.isEmpty(customizedTraceTopic) ? producerConfig.getCustomizedTraceTopic() : customizedTraceTopic;
+
+        if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
+            producer = new DefaultMQProducer(groupName, new AclClientRPCHook(new SessionCredentials(ak, sk)),
+                    annotation.enableMsgTrace(), customizedTraceTopic);
+            producer.setVipChannelEnabled(false);
+        } else {
+            producer = new DefaultMQProducer(groupName, annotation.enableMsgTrace(), customizedTraceTopic);
+        }
+
+        producer.setNamesrvAddr(nameServer);
+        producer.setSendMsgTimeout(annotation.sendMessageTimeout() == -1 ? producerConfig.getSendMessageTimeout() : annotation.sendMessageTimeout());
+        producer.setRetryTimesWhenSendFailed(annotation.retryTimesWhenSendAsyncFailed() == -1 ? producerConfig.getRetryTimesWhenSendFailed() : annotation.retryTimesWhenSendAsyncFailed());
+        producer.setRetryTimesWhenSendAsyncFailed(annotation.retryTimesWhenSendAsyncFailed() == -1 ? producerConfig.getRetryTimesWhenSendAsyncFailed() : annotation.retryTimesWhenSendAsyncFailed());
+        producer.setMaxMessageSize(annotation.maxMessageSize() == -1 ? producerConfig.getMaxMessageSize() : annotation.maxMessageSize());
+        producer.setCompressMsgBodyOverHowmuch(annotation.compressMessageBodyThreshold() == -1 ? producerConfig.getCompressMessageBodyThreshold() : annotation.compressMessageBodyThreshold());
+        producer.setRetryAnotherBrokerWhenNotStoreOK(annotation.retryNextServer());
+
+        return producer;
+    }
+
+    private void validate(ExtRocketMQTemplateConfiguration annotation, GenericApplicationContext genericApplicationContext) {
+        if (genericApplicationContext.isBeanNameInUse(annotation.value())) {
+            throw new BeanDefinitionValidationException(String.format("Bean {} has been used in Spring Application Context, " +
+                            "please check the @ExtRocketMQTemplateConfiguration",
+                    annotation.value()));
+        }
+
+        if (rocketMQProperties.getNameServer() == null ||
+                rocketMQProperties.getNameServer().equals(environment.resolvePlaceholders(annotation.nameServer()))) {
+            throw new BeanDefinitionValidationException(
+                    "Bad annotation definition in @ExtRocketMQTemplateConfiguration, nameServer property is same with " +
+                            "global property, please use the default RocketMQTemplate!");
+        }
+    }
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -93,7 +93,7 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
         GenericApplicationContext genericApplicationContext = (GenericApplicationContext) applicationContext;
 
         genericApplicationContext.registerBean(containerBeanName, DefaultRocketMQListenerContainer.class,
-            () -> createRocketMQListenerContainer(bean, annotation));
+            () -> createRocketMQListenerContainer(containerBeanName, bean, annotation));
         DefaultRocketMQListenerContainer container = genericApplicationContext.getBean(containerBeanName,
             DefaultRocketMQListenerContainer.class);
         if (!container.isRunning()) {
@@ -108,7 +108,7 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
         log.info("Register the listener to container, listenerBeanName:{}, containerBeanName:{}", beanName, containerBeanName);
     }
 
-    private DefaultRocketMQListenerContainer createRocketMQListenerContainer(Object bean, RocketMQMessageListener annotation) {
+    private DefaultRocketMQListenerContainer createRocketMQListenerContainer(String name, Object bean, RocketMQMessageListener annotation) {
         DefaultRocketMQListenerContainer container = new DefaultRocketMQListenerContainer();
 
         String nameServer = environment.resolvePlaceholders(annotation.nameServer());
@@ -119,6 +119,7 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
         container.setRocketMQMessageListener(annotation);
         container.setRocketMQListener((RocketMQListener) bean);
         container.setObjectMapper(objectMapper);
+        container.setName(name);  // REVIEW ME, use the same clientId or multiple?
 
         return container;
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -35,6 +35,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.StringUtils;
 
 import java.util.Map;
 import java.util.Objects;
@@ -110,7 +111,9 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
     private DefaultRocketMQListenerContainer createRocketMQListenerContainer(Object bean, RocketMQMessageListener annotation) {
         DefaultRocketMQListenerContainer container = new DefaultRocketMQListenerContainer();
 
-        container.setNameServer(rocketMQProperties.getNameServer());
+        String nameServer = environment.resolvePlaceholders(annotation.nameServer());
+        nameServer = StringUtils.isEmpty(nameServer) ? rocketMQProperties.getNameServer() : nameServer;
+        container.setNameServer(nameServer);
         container.setTopic(environment.resolvePlaceholders(annotation.topic()));
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));
         container.setRocketMQMessageListener(annotation);

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -26,6 +26,7 @@ import org.apache.rocketmq.spring.config.RocketMQConfigUtils;
 import org.apache.rocketmq.spring.config.RocketMQTransactionAnnotationProcessor;
 import org.apache.rocketmq.spring.config.TransactionHandlerRegistry;
 import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -85,7 +86,7 @@ public class RocketMQAutoConfiguration {
 
     @Bean(destroyMethod = "destroy")
     @ConditionalOnBean(DefaultMQProducer.class)
-    @ConditionalOnMissingBean(RocketMQTemplate.class)
+    @ConditionalOnMissingBean(name = RocketMQConfigUtils.ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME)
     public RocketMQTemplate rocketMQTemplate(DefaultMQProducer mqProducer, ObjectMapper rocketMQMessageObjectMapper) {
         RocketMQTemplate rocketMQTemplate = new RocketMQTemplate();
         rocketMQTemplate.setProducer(mqProducer);
@@ -94,9 +95,10 @@ public class RocketMQAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean(value = RocketMQTemplate.class, name = "rocketMQTemplate")
+    @ConditionalOnBean(name = RocketMQConfigUtils.ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME)
     @ConditionalOnMissingBean(TransactionHandlerRegistry.class)
-    public TransactionHandlerRegistry transactionHandlerRegistry(RocketMQTemplate template) {
+    public TransactionHandlerRegistry transactionHandlerRegistry(@Qualifier(RocketMQConfigUtils.ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME)
+                                                                             RocketMQTemplate template) {
         return new TransactionHandlerRegistry(template);
     }
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -45,7 +45,7 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(RocketMQProperties.class)
 @ConditionalOnClass({ MQAdmin.class, ObjectMapper.class })
 @ConditionalOnProperty(prefix = "rocketmq", value = "name-server")
-@Import({ JacksonFallbackConfiguration.class, ListenerContainerConfiguration.class })
+@Import({ JacksonFallbackConfiguration.class, ListenerContainerConfiguration.class, ExtProducerResetConfiguration.class })
 @AutoConfigureAfter(JacksonAutoConfiguration.class)
 public class RocketMQAutoConfiguration {
 
@@ -94,7 +94,7 @@ public class RocketMQAutoConfiguration {
     }
 
     @Bean
-    @ConditionalOnBean(RocketMQTemplate.class)
+    @ConditionalOnBean(value = RocketMQTemplate.class, name = "rocketMQTemplate")
     @ConditionalOnMissingBean(TransactionHandlerRegistry.class)
     public TransactionHandlerRegistry transactionHandlerRegistry(RocketMQTemplate template) {
         return new TransactionHandlerRegistry(template);

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/config/RocketMQConfigUtils.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/config/RocketMQConfigUtils.java
@@ -26,4 +26,7 @@ public class RocketMQConfigUtils {
 
     public static final String ROCKETMQ_TRANSACTION_DEFAULT_GLOBAL_NAME =
         "rocketmq_transaction_default_global_name";
+
+    public static final String ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME =
+            "rocketMQTemplate";
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
@@ -450,8 +450,9 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
 
     @Override
     public void afterPropertiesSet() throws Exception {
-        Assert.notNull(producer, "Property 'producer' is required");
-        producer.start();
+        if (producer != null) {
+            producer.start();
+        }
     }
 
     @Override

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -59,6 +59,11 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
     private ApplicationContext applicationContext;
 
+    /**
+     * The name of the DefaultRocketMQListenerContainer instance
+     */
+    private String name;
+
     private long suspendCurrentQueueTimeMillis = 1000;
 
     /**
@@ -94,6 +99,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
     private SelectorType selectorType;
     private String selectorExpression;
     private MessageModel messageModel;
+    private long consumeTimeout;
 
     public long getSuspendCurrentQueueTimeMillis() {
         return suspendCurrentQueueTimeMillis;
@@ -176,6 +182,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.messageModel = anno.messageModel();
         this.selectorExpression = anno.selectorExpression();
         this.selectorType = anno.selectorType();
+        this.consumeTimeout = anno.consumeTimeout();
     }
 
     public ConsumeMode getConsumeMode() {
@@ -294,6 +301,10 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
             ", selectorExpression='" + selectorExpression + '\'' +
             ", messageModel=" + messageModel +
             '}';
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public class DefaultMessageListenerConcurrently implements MessageListenerConcurrently {
@@ -424,6 +435,8 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         if (consumeThreadMax < consumer.getConsumeThreadMin()) {
             consumer.setConsumeThreadMin(consumeThreadMax);
         }
+        consumer.setConsumeTimeout(consumeTimeout);
+        consumer.setInstanceName(this.name);
 
         switch (messageModel) {
             case BROADCASTING:

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -414,7 +414,12 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
                     resolveRequiredPlaceholders(this.rocketMQMessageListener.customizedTraceTopic()));
         }
 
-        consumer.setNamesrvAddr(nameServer);
+        String customizedNameServer = this.applicationContext.getEnvironment().resolveRequiredPlaceholders(this.rocketMQMessageListener.nameServer());
+        if (customizedNameServer != null) {
+            consumer.setNamesrvAddr(customizedNameServer);
+        } else {
+            consumer.setNamesrvAddr(nameServer);
+        }
         consumer.setConsumeThreadMax(consumeThreadMax);
         if (consumeThreadMax < consumer.getConsumeThreadMin()) {
             consumer.setConsumeThreadMin(consumeThreadMax);


### PR DESCRIPTION
## What is the purpose of the change

1. Add an extra optional property 'nameServer' for @RocketMQMessageListener, to define a different nameserver for Consumer
2. Support to define and use extra RocketMQTemplate, which can have different nameServer or other properties 

For details, please see the README.md and new code in samples. 

