### PR TITLE
[ISSUE #103]Support resolvePlaceholders for selectorExpression

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -126,7 +126,9 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
 
     private DefaultRocketMQListenerContainer createRocketMQListenerContainer(String name, Object bean, RocketMQMessageListener annotation) {
         DefaultRocketMQListenerContainer container = new DefaultRocketMQListenerContainer();
-
+        
+        container.setRocketMQMessageListener(annotation);
+        
         String nameServer = environment.resolvePlaceholders(annotation.nameServer());
         nameServer = StringUtils.isEmpty(nameServer) ? rocketMQProperties.getNameServer() : nameServer;
         String accessChannel = environment.resolvePlaceholders(annotation.accessChannel());
@@ -140,7 +142,6 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
             container.setSelectorExpression(tags);
         }
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));
-        container.setRocketMQMessageListener(annotation);
         container.setRocketMQListener((RocketMQListener) bean);
         container.setObjectMapper(objectMapper);
         container.setName(name);  // REVIEW ME, use the same clientId or multiple?

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -135,10 +135,10 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
             container.setAccessChannel(AccessChannel.valueOf(accessChannel));
         }
         container.setTopic(environment.resolvePlaceholders(annotation.topic()));
-		String tags = environment.resolvePlaceholders(annotation.selectorExpression());
-		if (!StringUtils.isEmpty(tags)) {
-			container.setSelectorExpression(tags);
-		}
+        String tags = environment.resolvePlaceholders(annotation.selectorExpression());
+        if (!StringUtils.isEmpty(tags)) {
+            container.setSelectorExpression(tags);
+        }
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));
         container.setRocketMQMessageListener(annotation);
         container.setRocketMQListener((RocketMQListener) bean);

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -135,6 +135,10 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
             container.setAccessChannel(AccessChannel.valueOf(accessChannel));
         }
         container.setTopic(environment.resolvePlaceholders(annotation.topic()));
+		String tags = environment.resolvePlaceholders(annotation.selectorExpression());
+		if (!StringUtils.isEmpty(tags)) {
+			container.setSelectorExpression(tags);
+		}
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));
         container.setRocketMQMessageListener(annotation);
         container.setRocketMQListener((RocketMQListener) bean);

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -191,6 +191,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.consumeMode = anno.consumeMode();
         this.consumeThreadMax = anno.consumeThreadMax();
         this.messageModel = anno.messageModel();
+        this.selectorExpression = anno.selectorExpression();
         this.selectorType = anno.selectorType();
         this.consumeTimeout = anno.consumeTimeout();
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -191,7 +191,6 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.consumeMode = anno.consumeMode();
         this.consumeThreadMax = anno.consumeThreadMax();
         this.messageModel = anno.messageModel();
-        this.selectorExpression = anno.selectorExpression();
         this.selectorType = anno.selectorType();
         this.consumeTimeout = anno.consumeTimeout();
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -204,6 +204,10 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         return selectorType;
     }
 
+	public void setSelectorExpression(String selectorExpression) {
+		this.selectorExpression = selectorExpression;
+	}
+    
     public String getSelectorExpression() {
         return selectorExpression;
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -204,10 +204,10 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         return selectorType;
     }
 
-	public void setSelectorExpression(String selectorExpression) {
-		this.selectorExpression = selectorExpression;
-	}
-    
+    public void setSelectorExpression(String selectorExpression) {
+        this.selectorExpression = selectorExpression;
+    }
+
     public String getSelectorExpression() {
         return selectorExpression;
     }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
@@ -170,7 +170,7 @@ public class RocketMQAutoConfigurationTest {
                 "demo.rocketmq.transaction.producer.group=transaction-group1").
                 withUserConfiguration(TestTransactionListenerConfig.class).
                 run((context) -> {
-                    assertThat(context).hasSingleBean(MyRocketMQLocalTransactionListener.class);
+                    assertThat(context).hasSingleBean(TestRocketMQLocalTransactionListener.class);
 
                 });
 
@@ -259,13 +259,13 @@ public class RocketMQAutoConfigurationTest {
     static class TestTransactionListenerConfig {
         @Bean
         public Object rocketMQLocalTransactionListener() {
-            return new MyRocketMQLocalTransactionListener();
+            return new TestRocketMQLocalTransactionListener();
         }
 
     }
 
     @RocketMQTransactionListener(txProducerGroup = "${demo.rocketmq.transaction.producer.group}")
-    static class MyRocketMQLocalTransactionListener implements RocketMQLocalTransactionListener {
+    static class TestRocketMQLocalTransactionListener implements RocketMQLocalTransactionListener {
 
 
         @Override

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
@@ -130,7 +130,7 @@ public class RocketMQAutoConfigurationTest {
     @Test
     public void testExtRocketMQTemplate() {
         runner.withPropertyValues("rocketmq.name-server=127.0.0.1:9876").
-                withUserConfiguration(ExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
+                withUserConfiguration(TestExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
                 run(new ContextConsumer<AssertableApplicationContext>() {
                     @Override
                     public void accept(AssertableApplicationContext context) throws Throwable {
@@ -141,7 +141,7 @@ public class RocketMQAutoConfigurationTest {
                 });
 
         runner.withPropertyValues("rocketmq.name-server=127.0.1.1:9876").
-                withUserConfiguration(ExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
+                withUserConfiguration(TestExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
                 run((context) -> {
                     // No producer on consume side
                     assertThat(context).getBean("extRocketMQTemplate").hasFieldOrProperty("producer");
@@ -202,12 +202,12 @@ public class RocketMQAutoConfigurationTest {
 
         @Bean
         public Object consumeListener() {
-            return new MyMessageListener();
+            return new TestDefaultNameServerListener();
         }
 
         @Bean
         public Object consumeListener1() {
-            return new MyMessageListener1();
+            return new TestCustomNameServerListener();
         }
 
     }
@@ -238,7 +238,7 @@ public class RocketMQAutoConfigurationTest {
     }
 
     @RocketMQMessageListener(consumerGroup = "abc", topic = "test")
-    static class MyMessageListener implements RocketMQListener {
+    static class TestDefaultNameServerListener implements RocketMQListener {
 
         @Override
         public void onMessage(Object message) {
@@ -247,7 +247,7 @@ public class RocketMQAutoConfigurationTest {
     }
 
     @RocketMQMessageListener(nameServer = "127.0.1.1:9876", consumerGroup = "abc1", topic = "test")
-    static class MyMessageListener1 implements RocketMQListener {
+    static class TestCustomNameServerListener implements RocketMQListener {
 
         @Override
         public void onMessage(Object message) {
@@ -280,17 +280,17 @@ public class RocketMQAutoConfigurationTest {
     }
 
     @Configuration
-    static class ExtRocketMQTemplateConfig {
+    static class TestExtRocketMQTemplateConfig {
 
         @Bean
         public RocketMQTemplate extRocketMQTemplate() {
-            return new MyExtRocketMQTemplate();
+            return new TestExtRocketMQTemplate();
         }
 
     }
 
     @ExtRocketMQTemplateConfiguration(group = "test", nameServer = "127.0.0.1:9876")
-    static class MyExtRocketMQTemplate extends RocketMQTemplate {
+    static class TestExtRocketMQTemplate extends RocketMQTemplate {
 
     }
 


### PR DESCRIPTION
@RocketMQMessageListener(topic =
"${demo.rocketmq.test.consumer.topic}",selectorExpression="${demo.rocketmq.test.consumer.tags}"
,consumerGroup = "${demo.rocketmq.test.consumer.group}")

## What is the purpose of the change

purpose to support resolvePlaceholders for selectorExpression

## Brief changelog
modify ListenerContainerConfiguration.java
modify DefaultRocketMQListenerContainer.java