### PR TITLE
fix sendMessageInTransaction error "No route info of this topic" in aliyun mq

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
@@ -27,6 +27,7 @@ import org.apache.rocketmq.client.producer.SendResult;
 import org.apache.rocketmq.client.producer.TransactionMQProducer;
 import org.apache.rocketmq.client.producer.TransactionSendResult;
 import org.apache.rocketmq.client.producer.selector.SelectMessageQueueByHash;
+import org.apache.rocketmq.common.utils.NameServerAddressUtils;
 import org.apache.rocketmq.remoting.RPCHook;
 import org.apache.rocketmq.spring.config.RocketMQConfigUtils;
 import org.apache.rocketmq.spring.support.RocketMQUtil;
@@ -660,11 +661,15 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
         }
         txProducer.setTransactionListener(RocketMQUtil.convert(transactionListener));
 
-        txProducer.setNamesrvAddr(producer.getNamesrvAddr());
+        // this.producer.getNamesrvAddr() will remove prefix "http://"
+        // lead to sendMessageInTransaction get null namespace
+        txProducer.setNamesrvAddr(NameServerAddressUtils.ENDPOINT_PREFIX + this.producer.getNamesrvAddr());
         if (executorService != null) {
             txProducer.setExecutorService(executorService);
         }
 
+        // support set accessChannel as CLOUD
+        txProducer.setAccessChannel(this.producer.getAccessChannel());
         txProducer.setSendMsgTimeout(producer.getSendMsgTimeout());
         txProducer.setRetryTimesWhenSendFailed(producer.getRetryTimesWhenSendFailed());
         txProducer.setRetryTimesWhenSendAsyncFailed(producer.getRetryTimesWhenSendAsyncFailed());

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
@@ -663,6 +663,8 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
 
         // this.producer.getNamesrvAddr() will remove prefix "http://"
         // lead to sendMessageInTransaction get null namespace
+        // return error "org.apache.rocketmq.client.exception.MQClientException: No route info of this topic"
+        // add NameServerAddressUtils.ENDPOINT_PREFIX to fix
         txProducer.setNamesrvAddr(NameServerAddressUtils.ENDPOINT_PREFIX + this.producer.getNamesrvAddr());
         if (executorService != null) {
             txProducer.setExecutorService(executorService);

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
@@ -661,9 +661,8 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
         }
         txProducer.setTransactionListener(RocketMQUtil.convert(transactionListener));
 
-        // this.producer.getNamesrvAddr() will remove prefix "http://"
-        // lead to sendMessageInTransaction get null namespace
-        // return error "org.apache.rocketmq.client.exception.MQClientException: No route info of this topic"
+        // this.producer.getNamesrvAddr() will remove prefix "http://" and sendMessageInTransaction will get null namespace
+        // error: "org.apache.rocketmq.client.exception.MQClientException: No route info of this topic" when use aliyun mq
         // add NameServerAddressUtils.ENDPOINT_PREFIX to fix
         txProducer.setNamesrvAddr(NameServerAddressUtils.ENDPOINT_PREFIX + this.producer.getNamesrvAddr());
         if (executorService != null) {


### PR DESCRIPTION
## What is the purpose of the change

Fix sendMessageInTransaction error "No route info of this topic" in aliyun mq.

## Brief changelog
The method createTransactionMQProducer in class RocketMQTemplate use `producer.getNamesrvAddr()` to set txProducer namesrvAddr that miss prifix "http://". So get error "No route info of this topic" when use 2.0.4-SNAPSHOT sdk to send transation msg in aliyun MQ service.
```
// fix namesrvAddr no right
txProducer.setNamesrvAddr(NameServerAddressUtils.ENDPOINT_PREFIX + this.producer.getNamesrvAddr());
```
`txProducer.setAccessChannel(this.producer.getAccessChannel());` to set accessChannel as rocketmq.access-channel.

## Verifying this change
The changes is Verified in my project QA environment.