### PR TITLE
[ISSUE #197] Solve the problem that RocketMQListener can not deserialize generic onMessage method parameter

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -58,7 +58,7 @@ import org.springframework.util.Assert;
 
 @SuppressWarnings("WeakerAccess")
 public class DefaultRocketMQListenerContainer implements InitializingBean,
-        RocketMQListenerContainer, SmartLifecycle, ApplicationContextAware {
+    RocketMQListenerContainer, SmartLifecycle, ApplicationContextAware {
     private final static Logger log = LoggerFactory.getLogger(DefaultRocketMQListenerContainer.class);
 
     private ApplicationContext applicationContext;
@@ -314,14 +314,14 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
     @Override
     public String toString() {
         return "DefaultRocketMQListenerContainer{" +
-                "consumerGroup='" + consumerGroup + '\'' +
-                ", nameServer='" + nameServer + '\'' +
-                ", topic='" + topic + '\'' +
-                ", consumeMode=" + consumeMode +
-                ", selectorType=" + selectorType +
-                ", selectorExpression='" + selectorExpression + '\'' +
-                ", messageModel=" + messageModel +
-                '}';
+            "consumerGroup='" + consumerGroup + '\'' +
+            ", nameServer='" + nameServer + '\'' +
+            ", topic='" + topic + '\'' +
+            ", consumeMode=" + consumeMode +
+            ", selectorType=" + selectorType +
+            ", selectorExpression='" + selectorExpression + '\'' +
+            ", messageModel=" + messageModel +
+            '}';
     }
 
     public void setName(String name) {
@@ -387,7 +387,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
                 // If msgType not string, use objectMapper change it.
                 try {
                     if (messageType instanceof Class) {
-                        //if the messageType is has not Generic Parameter
+                        //if the messageType has not Generic Parameter
                         return this.getMessageConverter().fromMessage(MessageBuilder.withPayload(str).build(), (Class<?>) messageType);
                     } else {
                         //if the messageType has Generic Parameter, then use SmartMessageConverter#fromMessage with third parameter "conversionHint".
@@ -459,19 +459,19 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         Assert.notNull(topic, "Property 'topic' is required");
 
         RPCHook rpcHook = RocketMQUtil.getRPCHookByAkSk(applicationContext.getEnvironment(),
-                this.rocketMQMessageListener.accessKey(), this.rocketMQMessageListener.secretKey());
+            this.rocketMQMessageListener.accessKey(), this.rocketMQMessageListener.secretKey());
         boolean enableMsgTrace = rocketMQMessageListener.enableMsgTrace();
         if (Objects.nonNull(rpcHook)) {
             consumer = new DefaultMQPushConsumer(consumerGroup, rpcHook, new AllocateMessageQueueAveragely(),
-                    enableMsgTrace, this.applicationContext.getEnvironment().
-                    resolveRequiredPlaceholders(this.rocketMQMessageListener.customizedTraceTopic()));
+                enableMsgTrace, this.applicationContext.getEnvironment().
+                resolveRequiredPlaceholders(this.rocketMQMessageListener.customizedTraceTopic()));
             consumer.setVipChannelEnabled(false);
             consumer.setInstanceName(RocketMQUtil.getInstanceName(rpcHook, consumerGroup));
         } else {
             log.debug("Access-key or secret-key not configure in " + this + ".");
             consumer = new DefaultMQPushConsumer(consumerGroup, enableMsgTrace,
                     this.applicationContext.getEnvironment().
-                            resolveRequiredPlaceholders(this.rocketMQMessageListener.customizedTraceTopic()));
+                    resolveRequiredPlaceholders(this.rocketMQMessageListener.customizedTraceTopic()));
         }
 
         String customizedNameServer = this.applicationContext.getEnvironment().resolveRequiredPlaceholders(this.rocketMQMessageListener.nameServer());

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -17,11 +17,21 @@
 
 package org.apache.rocketmq.spring.support;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Objects;
 import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.MessageSelector;
-import org.apache.rocketmq.client.consumer.listener.*;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
 import org.apache.rocketmq.client.consumer.rebalance.AllocateMessageQueueAveragely;
 import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.common.message.MessageExt;
@@ -45,13 +55,6 @@ import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.converter.SmartMessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.Assert;
-
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
-import java.nio.charset.Charset;
-import java.util.List;
-import java.util.Objects;
 
 @SuppressWarnings("WeakerAccess")
 public class DefaultRocketMQListenerContainer implements InitializingBean,

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -405,7 +405,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
     private MethodParameter getMethodParameter() {
         Class<?> targetClass = AopProxyUtils.ultimateTargetClass(rocketMQListener);
-        Type messageType = this.messageType;
+        Type messageType = this.getMessageType();
         Class clazz = null;
         if (messageType instanceof ParameterizedType && messageConverter instanceof SmartMessageConverter) {
             clazz = (Class) ((ParameterizedType) messageType).getRawType();

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -16,10 +16,19 @@
  */
 package org.apache.rocketmq.spring.support;
 
-import java.lang.reflect.Method;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.spring.core.RocketMQListener;
 import org.junit.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.messaging.converter.CompositeMessageConverter;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.messaging.converter.StringMessageConverter;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +54,28 @@ public class DefaultRocketMQListenerContainerTest {
         });
         result = (Class) getMessageType.invoke(listenerContainer);
         assertThat(result.getName().equals(MessageExt.class.getName()));
+    }
+
+    @Test
+    public void testGenericMessageType() throws Exception {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+        listenerContainer.setMessageConverter(new CompositeMessageConverter(Arrays.asList(new StringMessageConverter(), new MappingJackson2MessageConverter())));
+
+        Method getMessageType = DefaultRocketMQListenerContainer.class.getDeclaredMethod("getMessageType");
+        Method getMethodParameter = DefaultRocketMQListenerContainer.class.getDeclaredMethod("getMethodParameter");
+        getMessageType.setAccessible(true);
+        getMethodParameter.setAccessible(true);
+        listenerContainer.setRocketMQListener(new RocketMQListener<ArrayList<Date>>() {
+            @Override
+            public void onMessage(ArrayList<Date> message) {
+
+            }
+        });
+
+        ParameterizedType type = (ParameterizedType) getMessageType.invoke(listenerContainer);
+        assertThat(type.getRawType() == ArrayList.class);
+        MethodParameter methodParameter = ((MethodParameter) getMethodParameter.invoke(listenerContainer));
+        System.out.println(methodParameter);
     }
 }
 

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -16,6 +16,8 @@
  */
 package org.apache.rocketmq.spring.support;
 
+import java.lang.reflect.Method;
+import java.lang.reflect.ParameterizedType;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.spring.core.RocketMQListener;
 import org.junit.Test;
@@ -24,8 +26,6 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -75,7 +75,7 @@ public class DefaultRocketMQListenerContainerTest {
         ParameterizedType type = (ParameterizedType) getMessageType.invoke(listenerContainer);
         assertThat(type.getRawType() == ArrayList.class);
         MethodParameter methodParameter = ((MethodParameter) getMethodParameter.invoke(listenerContainer));
-        System.out.println(methodParameter);
+        assertThat(methodParameter.getParameterType() == ArrayList.class);
     }
 }
 


### PR DESCRIPTION
**Problems:**
When definition the listener like this. the starter cannot settup
`public class Listener1 implements RocketMQListener<MsgDto<String>>`


Recently, I tryied solve this problem,only modify the DefaultRocketMQListenerContainer class.  **Wish to improve the starter in next release.**
1. My Main idea is use org.springframework.messaging.converter.SmartMessageConverter#fromMessage .This interface define a third parameter called "Object conversionHint".
2. I switch the Definition of DefaultRocketMQListenerContainer#messageType to Type insteadof Class
3. add a "private  MethodParameter onMessageParameter" member  to DefaultRocketMQListenerContainer and init it to indicate the onMessage parameter when afterPropertiesSet() 
4. when doCovertMessage. if the messageType instanceof  ParameterizedType, then call fromMessage with the third parameter(methodParameter). The MappingJackson2MessageConverter can use it to deserialization the message.