### PR TITLE
[ISSUE #88] Consumer Batch API 

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.spring.annotation.ConsumeMode;
 import org.apache.rocketmq.spring.annotation.MessageModel;
 import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.core.RocketMQBatchListener;
 import org.apache.rocketmq.spring.core.RocketMQListener;
 import org.apache.rocketmq.spring.support.DefaultRocketMQListenerContainer;
 import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
@@ -140,7 +141,12 @@ public class ListenerContainerConfiguration implements ApplicationContextAware, 
             container.setSelectorExpression(tags);
         }
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));
-        container.setRocketMQListener((RocketMQListener)bean);
+        if (bean instanceof RocketMQBatchListener) {
+            container.setRocketMQBatchListener((RocketMQBatchListener)bean);
+        }
+        else {
+            container.setRocketMQListener((RocketMQListener)bean);
+        }
         container.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
         container.setName(name);  // REVIEW ME, use the same clientId or multiple?
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQBatchListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQBatchListener.java
@@ -14,24 +14,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.rocketmq.spring.core;
 
-package org.apache.rocketmq.spring.support;
+import java.util.List;
 
-import org.apache.rocketmq.spring.core.RocketMQBatchListener;
-import org.apache.rocketmq.spring.core.RocketMQListener;
-import org.springframework.beans.factory.DisposableBean;
-
-public interface RocketMQListenerContainer extends DisposableBean {
+public interface RocketMQBatchListener<T> {
 
     /**
-     * Setup the message listener to use. Throws an {@link IllegalArgumentException} if that message listener type is
-     * not supported.
+     * Batch consume bulk Java Objects once.
+     *
+     * @param messages bulk Java Objects.
      */
-    void setupMessageListener(RocketMQListener<?> messageListener);
-
-   /**
-     * Setup the message batch listener to use. Throws an {@link IllegalArgumentException} if that message listener type is
-     * not supported.
-     */
-    void setupMessageBatchListener(RocketMQBatchListener<?> messageListener);
+    void onMessages(List<T> messages);
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -23,6 +23,9 @@ import java.lang.reflect.Type;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Objects;
+
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.ObjectUtils;
 import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
 import org.apache.rocketmq.client.consumer.MessageSelector;
@@ -40,6 +43,7 @@ import org.apache.rocketmq.spring.annotation.ConsumeMode;
 import org.apache.rocketmq.spring.annotation.MessageModel;
 import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
 import org.apache.rocketmq.spring.annotation.SelectorType;
+import org.apache.rocketmq.spring.core.RocketMQBatchListener;
 import org.apache.rocketmq.spring.core.RocketMQListener;
 import org.apache.rocketmq.spring.core.RocketMQPushConsumerLifecycleListener;
 import org.slf4j.Logger;
@@ -91,6 +95,8 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
     private MessageConverter messageConverter;
 
     private RocketMQListener rocketMQListener;
+
+    private RocketMQBatchListener rocketMQBatchListener;
 
     private RocketMQMessageListener rocketMQMessageListener;
 
@@ -186,6 +192,18 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.rocketMQListener = rocketMQListener;
     }
 
+    public RocketMQBatchListener getRocketMQBatchListener() {
+        return rocketMQBatchListener;
+    }
+
+    public void setRocketMQBatchListener(RocketMQBatchListener rocketMQBatchListener) {
+        this.rocketMQBatchListener = rocketMQBatchListener;
+    }
+
+    private Object getCandidateRocketMQListener() {
+        return ObjectUtils.defaultIfNull(rocketMQBatchListener, rocketMQListener);
+    }
+
     public RocketMQMessageListener getRocketMQMessageListener() {
         return rocketMQMessageListener;
     }
@@ -231,7 +249,14 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
     @Override
     public void setupMessageListener(RocketMQListener rocketMQListener) {
+        this.rocketMQBatchListener = null;
         this.rocketMQListener = rocketMQListener;
+    }
+
+    @Override
+    public void setupMessageBatchListener(RocketMQBatchListener<?> rocketMQBatchListener) {
+        this.rocketMQListener = null;
+        this.rocketMQBatchListener = rocketMQBatchListener;
     }
 
     @Override
@@ -372,8 +397,58 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
             return ConsumeOrderlyStatus.SUCCESS;
         }
+
     }
 
+    private class BatchMessageListenerConcurrently implements MessageListenerConcurrently {
+
+        @Override
+        public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs, ConsumeConcurrentlyContext context) {
+            try {
+                batchConsumeMessages(msgs);
+            } catch (Exception e) {
+                log.warn("consume message failed. messageExt:{}", msgs, e);
+                context.setDelayLevelWhenNextConsume(delayLevelWhenNextConsume);
+                return ConsumeConcurrentlyStatus.RECONSUME_LATER;
+            }
+
+            return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+        }
+    }
+
+    private class BatchMessageListenerOrderly implements MessageListenerOrderly {
+
+        @Override
+        public ConsumeOrderlyStatus consumeMessage(List<MessageExt> msgs, ConsumeOrderlyContext context) {
+            try {
+                batchConsumeMessages(msgs);
+            }
+            catch (Exception e) {
+                log.warn("consume message failed. messageExt:{}", msgs, e);
+                context.setSuspendCurrentQueueTimeMillis(suspendCurrentQueueTimeMillis);
+                return ConsumeOrderlyStatus.SUSPEND_CURRENT_QUEUE_A_MOMENT;
+            }
+
+            return ConsumeOrderlyStatus.SUCCESS;
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private boolean batchConsumeMessages(List<MessageExt> msgs) {
+        log.debug("received msgs, size: {}", msgs.size());
+        long now = System.currentTimeMillis();
+        try {
+            List messages = msgs.stream().map(DefaultRocketMQListenerContainer.this::doConvertMessage).collect(Collectors.toList());
+            rocketMQBatchListener.onMessages(messages);
+        }
+        finally {
+            if (log.isDebugEnabled()) {
+                long costTime = System.currentTimeMillis() - now;
+                log.debug("batch consume {} cost: {} ms", msgs.stream().map(MessageExt::getMsgId).collect(Collectors.toList()), costTime);
+            }
+        }
+        return true;
+    }
 
     @SuppressWarnings("unchecked")
     private Object doConvertMessage(MessageExt messageExt) {
@@ -401,7 +476,6 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
             }
         }
     }
-
 
     private MethodParameter getMethodParameter() {
         Class<?> targetClass = AopProxyUtils.ultimateTargetClass(rocketMQListener);
@@ -453,7 +527,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
     }
 
     private void initRocketMQPushConsumer() throws MQClientException {
-        Assert.notNull(rocketMQListener, "Property 'rocketMQListener' is required");
+        Assert.notNull(getCandidateRocketMQListener(), "Property 'rocketMQBatchListener' or 'rocketMQListener' is required");
         Assert.notNull(consumerGroup, "Property 'consumerGroup' is required");
         Assert.notNull(nameServer, "Property 'nameServer' is required");
         Assert.notNull(topic, "Property 'topic' is required");
@@ -511,21 +585,26 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
                 throw new IllegalArgumentException("Property 'selectorType' was wrong.");
         }
 
+        initConsumeMode();
+
+        Object candidateRocketMQListener = getCandidateRocketMQListener();
+        if (candidateRocketMQListener instanceof RocketMQPushConsumerLifecycleListener) {
+            ((RocketMQPushConsumerLifecycleListener)candidateRocketMQListener).prepareStart(consumer);
+        }
+
+    }
+
+    private void initConsumeMode() {
         switch (consumeMode) {
             case ORDERLY:
-                consumer.setMessageListener(new DefaultMessageListenerOrderly());
+                consumer.setMessageListener((rocketMQBatchListener != null) ? (new BatchMessageListenerOrderly()) : (new DefaultMessageListenerOrderly()));
                 break;
             case CONCURRENTLY:
-                consumer.setMessageListener(new DefaultMessageListenerConcurrently());
+                consumer.setMessageListener((rocketMQBatchListener != null) ? (new BatchMessageListenerConcurrently()) : (new DefaultMessageListenerConcurrently()));
                 break;
             default:
                 throw new IllegalArgumentException("Property 'consumeMode' was wrong.");
         }
-
-        if (rocketMQListener instanceof RocketMQPushConsumerLifecycleListener) {
-            ((RocketMQPushConsumerLifecycleListener) rocketMQListener).prepareStart(consumer);
-        }
-
     }
 
 }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -16,9 +16,32 @@
  */
 package org.apache.rocketmq.spring.support;
 
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeOrderlyContext;
+import org.apache.rocketmq.client.consumer.listener.MessageListener;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerOrderly;
 import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.spring.annotation.ConsumeMode;
+import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.annotation.SelectorType;
+import org.apache.rocketmq.spring.core.RocketMQBatchListener;
 import org.apache.rocketmq.spring.core.RocketMQListener;
 import org.junit.Test;
 import org.springframework.core.MethodParameter;
@@ -26,11 +49,8 @@ import org.springframework.messaging.converter.CompositeMessageConverter;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.converter.StringMessageConverter;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Date;
-
 import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class DefaultRocketMQListenerContainerTest {
     @Test
@@ -56,7 +76,7 @@ public class DefaultRocketMQListenerContainerTest {
         assertThat(result.getName().equals(MessageExt.class.getName()));
     }
 
-    @Test
+        @Test
     public void testGenericMessageType() throws Exception {
         DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
         listenerContainer.setMessageConverter(new CompositeMessageConverter(Arrays.asList(new StringMessageConverter(), new MappingJackson2MessageConverter())));
@@ -77,6 +97,160 @@ public class DefaultRocketMQListenerContainerTest {
         MethodParameter methodParameter = ((MethodParameter) getMethodParameter.invoke(listenerContainer));
         assertThat(methodParameter.getParameterType() == ArrayList.class);
     }
+
+    @Test
+    public void testConsumeMode() throws Exception {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+        listenerContainer.setConsumer(new DefaultMQPushConsumer());
+        Method initConsumeMode = DefaultRocketMQListenerContainer.class.getDeclaredMethod("initConsumeMode");
+        initConsumeMode.setAccessible(true);
+
+        listenerContainer.setRocketMQMessageListener(ConcurrentlyClass.class.getAnnotation(RocketMQMessageListener.class));
+        initConsumeMode.invoke(listenerContainer);
+        assertThat(listenerContainer.getConsumer().getMessageListener() instanceof MessageListenerConcurrently).isTrue(); // excepted
+
+        listenerContainer.setRocketMQMessageListener(OrderlyClass.class.getAnnotation(RocketMQMessageListener.class));
+        initConsumeMode.invoke(listenerContainer);
+        assertThat(listenerContainer.getConsumer().getMessageListener() instanceof MessageListenerOrderly).isTrue(); // excepted
+    }
+
+    private final String notExceptedString = "not excepted test string msg type";
+    private final String exceptedString = "test string msg type";
+
+    @RocketMQMessageListener(consumerGroup = "consumerGroup1", topic = "test", selectorExpression = "*", selectorType = SelectorType.TAG)
+    static class TagClass {
+    }
+
+    @RocketMQMessageListener(consumerGroup = "consumerGroup1", topic = "test", selectorType = SelectorType.SQL92)
+    static class SQL92Class {
+    }
+
+    @RocketMQMessageListener(consumerGroup = "consumerGroup1", topic = "test", consumeMode = ConsumeMode.CONCURRENTLY)
+    static class ConcurrentlyClass {
+    }
+
+    @RocketMQMessageListener(consumerGroup = "consumerGroup1", topic = "test", consumeMode = ConsumeMode.ORDERLY)
+    static class OrderlyClass {
+    }
+
+    @Test
+    public void testBatchGetMessages() throws Exception {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+        listenerContainer.setConsumer(new DefaultMQPushConsumer());
+        Field messageType = DefaultRocketMQListenerContainer.class.getDeclaredField("messageType");
+        messageType.setAccessible(true);
+
+        ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                return new Thread(r, "TestScheduledThread");
+            }
+        });
+        Runnable r = () -> {
+            try {
+                MessageExt msg = new MessageExt();
+                msg.setMsgId("X_SVEN_AUGUSTUS_0001");
+                msg.setBody((exceptedString + " 1").getBytes(listenerContainer.getCharset()));
+                MessageExt msg2 = new MessageExt();
+                msg2.setMsgId("X_SVEN_AUGUSTUS_0002");
+                msg2.setBody((exceptedString + " 2").getBytes(listenerContainer.getCharset()));
+                List<MessageExt> messages = Arrays.asList(msg, msg2);
+
+                MessageListener l = listenerContainer.getConsumer().getMessageListener();
+                if (l instanceof MessageListenerConcurrently) {
+                    ((MessageListenerConcurrently)l).consumeMessage(messages, new ConsumeConcurrentlyContext(new MessageQueue()));
+                }
+                if (l instanceof MessageListenerOrderly) {
+                    ((MessageListenerOrderly)l).consumeMessage(messages, new ConsumeOrderlyContext(new MessageQueue()));
+                }
+            }
+            catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+        };
+        messageType.set(listenerContainer, String.class);
+
+        // RocketMQBatchListener IN ConsumeMode.CONCURRENTLY, AND test for excepted
+        tryRocketMQBatchListener(listenerContainer, ConcurrentlyClass.class, scheduledExecutorService, r, exceptedString, true);// excepted
+
+        // RocketMQBatchListener IN ConsumeMode.CONCURRENTLY, AND test for not excepted
+        tryRocketMQBatchListener(listenerContainer, ConcurrentlyClass.class, scheduledExecutorService, r, notExceptedString, false);// not excepted
+
+        // RocketMQBatchListener IN ConsumeMode.ORDERLY, AND test for excepted
+        tryRocketMQBatchListener(listenerContainer, OrderlyClass.class, scheduledExecutorService, r, exceptedString, true);// excepted
+
+        // RocketMQBatchListener IN ConsumeMode.ORDERLY, AND test for not excepted
+        tryRocketMQBatchListener(listenerContainer, OrderlyClass.class, scheduledExecutorService, r, notExceptedString, false);// not excepted
+
+        // RocketMQListener IN ConsumeMode.CONCURRENTLY, AND test for excepted
+        tryRocketMQListener(listenerContainer, ConcurrentlyClass.class, scheduledExecutorService, r, exceptedString, true);// excepted
+
+        // RocketMQListener IN ConsumeMode.CONCURRENTLY, AND test for not excepted
+        tryRocketMQListener(listenerContainer, ConcurrentlyClass.class, scheduledExecutorService, r, notExceptedString, false);// not excepted
+
+        // RocketMQListener IN ConsumeMode.ORDERLY, AND test for excepted
+        tryRocketMQListener(listenerContainer, OrderlyClass.class, scheduledExecutorService, r, exceptedString, true);// excepted
+
+        // RocketMQListener IN ConsumeMode.ORDERLY, AND test for not excepted
+        tryRocketMQListener(listenerContainer, OrderlyClass.class, scheduledExecutorService, r, notExceptedString, false);// not excepted
+    }
+
+    private void tryRocketMQBatchListener(DefaultRocketMQListenerContainer listenerContainer,
+        final Class<?> rocketMQMessageListenerClass,
+        ScheduledExecutorService scheduledExecutorService, Runnable r, final String exceptedValue,
+        boolean exceptedTrueOrFalse) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, InterruptedException {
+        Method initConsumeMode = DefaultRocketMQListenerContainer.class.getDeclaredMethod("initConsumeMode");
+        initConsumeMode.setAccessible(true);
+
+        final Boolean[] result = new Boolean[] {Boolean.FALSE};
+
+        // RocketMQBatchListener IN ConsumeMode.CONCURRENTLY, AND test for excepted
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        listenerContainer.setupMessageBatchListener(new RocketMQBatchListener<String>() {
+            @Override
+            public void onMessages(List<String> messages) {
+                result[0] = messages.stream().anyMatch(m -> m.startsWith(exceptedValue));
+                countDownLatch.countDown();
+            }
+        });
+        listenerContainer.setRocketMQMessageListener(rocketMQMessageListenerClass.getAnnotation(RocketMQMessageListener.class));
+        initConsumeMode.invoke(listenerContainer);
+        scheduledExecutorService.schedule(r, 100, TimeUnit.MILLISECONDS);
+        countDownLatch.await(1000, TimeUnit.MILLISECONDS);
+        if (exceptedTrueOrFalse)
+            assertThat(result[0]).isTrue(); // excepted
+        else
+            assertThat(result[0]).isFalse(); // not excepted
+    }
+
+    private void tryRocketMQListener(DefaultRocketMQListenerContainer listenerContainer,
+        final Class<?> rocketMQMessageListenerClass,
+        ScheduledExecutorService scheduledExecutorService, Runnable r, final String exceptedValue,
+        boolean exceptedTrueOrFalse) throws InvocationTargetException, IllegalAccessException, NoSuchMethodException, InterruptedException {
+        Method initConsumeMode = DefaultRocketMQListenerContainer.class.getDeclaredMethod("initConsumeMode");
+        initConsumeMode.setAccessible(true);
+
+        final Boolean[] result = new Boolean[] {Boolean.FALSE};
+
+        // RocketMQBatchListener IN ConsumeMode.CONCURRENTLY, AND test for excepted
+        final CountDownLatch countDownLatch = new CountDownLatch(1);
+        listenerContainer.setupMessageListener(new RocketMQListener<String>() {
+            @Override
+            public void onMessage(String message) {
+                result[0] = message.startsWith(exceptedValue);
+                countDownLatch.countDown();
+            }
+        });
+        listenerContainer.setRocketMQMessageListener(rocketMQMessageListenerClass.getAnnotation(RocketMQMessageListener.class));
+        initConsumeMode.invoke(listenerContainer);
+        scheduledExecutorService.schedule(r, 100, TimeUnit.MILLISECONDS);
+        countDownLatch.await(1000, TimeUnit.MILLISECONDS);
+        if (exceptedTrueOrFalse)
+            assertThat(result[0]).isTrue(); // excepted
+        else
+            assertThat(result[0]).isFalse(); // not excepted
+    }
+
 }
 
 


### PR DESCRIPTION
## What is the purpose of the change

Provides a new Consumer Batch API, instead of extending `RocketMQListener`.

## Brief changelog

- add `RocketMQBatchListener` .
- update `ListenerContainerConfiguration` to support `RocketMQBatchListener` by adding annotation `@RocketMQMessageListener` .
- update `DefaultRocketMQListenerContainer` consume messages functions: 
If field `rocketMQListener` is instacne of `RocketMQBatchListener` , then prior to execute batch api `RocketMQBatchListener#onMessages` insteading of `RocketMQListener#onMessage`.
Or defaults.



## Verifying this change

Unit Test is shown in `DefaultRocketMQListenerContainerTest#testBatchGetMessages` .

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
