### PR TITLE
[ISSUE #211] Remove the limitation that ExtRocketMQTemplate can not keep the same nameserver as RocketMQTemplate

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQTemplateConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQTemplateConfiguration.java
@@ -17,13 +17,12 @@
 
 package org.apache.rocketmq.spring.annotation;
 
-import org.springframework.stereotype.Component;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.springframework.stereotype.Component;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -38,7 +37,7 @@ public @interface ExtRocketMQTemplateConfiguration {
     /**
      * The property of "name-server".
      */
-    String nameServer();
+    String nameServer() default "${rocketmq.name-server:}";
 
     /**
      * Name of producer.

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
@@ -162,12 +162,5 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
                     "please check the @ExtRocketMQTemplateConfiguration",
                 annotation.value()));
         }
-
-        if (rocketMQProperties.getNameServer() == null ||
-            rocketMQProperties.getNameServer().equals(environment.resolvePlaceholders(annotation.nameServer()))) {
-            throw new BeanDefinitionValidationException(
-                "Bad annotation definition in @ExtRocketMQTemplateConfiguration, nameServer property is same with " +
-                    "global property, please use the default RocketMQTemplate!");
-        }
     }
 }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
@@ -32,11 +32,8 @@ import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
 import org.junit.Assert;
 import org.junit.Test;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-import org.springframework.beans.factory.support.BeanDefinitionValidationException;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
-import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
-import org.springframework.boot.test.context.runner.ContextConsumer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.Message;
@@ -88,17 +85,6 @@ public class RocketMQAutoConfigurationTest {
 
     @Test
     public void testExtRocketMQTemplate() {
-        runner.withPropertyValues("rocketmq.name-server=127.0.0.1:9876").
-            withUserConfiguration(TestExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
-            run(new ContextConsumer<AssertableApplicationContext>() {
-                @Override
-                public void accept(AssertableApplicationContext context) throws Throwable {
-                    Throwable th = context.getStartupFailure();
-                    System.out.printf("th==" + th + "\n");
-                    Assert.assertTrue(th instanceof BeanDefinitionValidationException);
-                }
-            });
-
         runner.withPropertyValues("rocketmq.name-server=127.0.1.1:9876").
             withUserConfiguration(TestExtRocketMQTemplateConfig.class, CustomObjectMappersConfig.class).
             run((context) -> {


### PR DESCRIPTION
## What is the purpose of the change

fix #211 

## Brief changelog

Remove the limitation that ExtRocketMQTemplate can not keep the same nameserver as RocketMQTemplate

## Verifying this change


Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
