### PR TITLE
[ISSUE #241] Make the unit of consumeTimeout in rocketmq-spring consistent with rocketmq client

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -76,9 +76,9 @@ public @interface RocketMQMessageListener {
     int consumeThreadMax() default 64;
 
     /**
-     * Max consumer timeout, default 30s.
+     * Maximum amount of time in minutes a message may block the consuming thread.
      */
-    long consumeTimeout() default 30000L;
+    long consumeTimeout() default 15L;
 
     /**
      * The property of "access-key".


### PR DESCRIPTION
## What is the purpose of the change

Fix #241 

## Brief changelog

Make the unit of consumeTimeout in rocketmq-spring consistent with rocketmq client

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
