### PR TITLE
restore http endpoint for get servers list

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
@@ -49,6 +49,58 @@ public class RocketMQProperties {
      */
     private Consumer consumer = new Consumer();
 
+    /**
+     * The http endpoint support for rocketMQ
+     */
+    private Discovery discovery = new Discovery();
+
+    public static class Discovery {
+        /**
+         * http discovery namesrv enabled
+         */
+        private boolean enabled = false;
+        /**
+         * domain, default: `jmenv.tbsite.net`.
+         */
+        private String domain = "jmenv.tbsite.net";
+        /**
+         * subdomain, default: `nsaddr`.
+         */
+        private String subDomain = "nsaddr";
+
+        public String getDomain() {
+            return domain;
+        }
+
+        public void setDomain(String domain) {
+            this.domain = domain;
+        }
+
+        public String getSubDomain() {
+            return subDomain;
+        }
+
+        public void setSubDomain(String subDomain) {
+            this.subDomain = subDomain;
+        }
+
+        public boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(boolean enabled) {
+            this.enabled = enabled;
+        }
+    }
+
+    public Discovery getDiscovery() {
+        return discovery;
+    }
+
+    public void setDiscovery(Discovery discovery) {
+        this.discovery = discovery;
+    }
+
     public String getNameServer() {
         return nameServer;
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -544,7 +544,6 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
             throw new IllegalArgumentException("Property 'rocketMQListener' or 'rocketMQReplyListener' is required");
         }
         Assert.notNull(consumerGroup, "Property 'consumerGroup' is required");
-        Assert.notNull(nameServer, "Property 'nameServer' is required");
         Assert.notNull(topic, "Property 'topic' is required");
 
         RPCHook rpcHook = RocketMQUtil.getRPCHookByAkSk(applicationContext.getEnvironment(),

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfigurationTest.java
@@ -46,10 +46,21 @@ public class RocketMQAutoConfigurationTest {
     private ApplicationContextRunner runner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(RocketMQAutoConfiguration.class));
 
-    @Test(expected = NoSuchBeanDefinitionException.class)
+    @Test(expected = IllegalStateException.class)
     public void testDefaultMQProducerNotCreatedByDefault() {
         // You will see the WARN log message about missing rocketmq.name-server spring property when running this test case.
         runner.run(context -> context.getBean(DefaultMQProducer.class));
+    }
+
+    @Test
+    public void testDefaultMQProducerDiscovery() {
+        // You will see the WARN log message about missing rocketmq.name-server spring property when running this test case.
+        runner.withPropertyValues("rocketmq.discovery.enabled=true", "rocketmq.producer.group=spring_rocketmq")
+            .run(context -> {
+                assertThat(context).hasSingleBean(DefaultMQProducer.class);
+                assertThat(context).hasSingleBean(RocketMQProperties.class);
+                context.getBean(DefaultMQProducer.class);
+            });
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

You lost support http endpoint for get list of servers from env - it breaks compatibility with ali-middlewares and maybe will be interesting for other guys

## Brief changelog

just add 3 properties
```
rocketmq.discovery.enabled=true # by default: false
rocketmq.discovery.domain=jmenv.tbsite.net  # by default: jmenv.tbsite.net
rocketmq.discovery.subdomain=nsaddr # by default: nsaddr
```

## Verifying this change

add test case

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
