### PR TITLE
[ISSUE #281] Utilize registerBeanDefinition to support SpringBoot 1

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -173,6 +173,10 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         return consumeThreadMax;
     }
 
+    public void setConsumeThreadMax(int consumeThreadMax) {
+        this.consumeThreadMax = consumeThreadMax;
+    }
+
     public String getCharset() {
         return charset;
     }
@@ -225,8 +229,16 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         return consumeMode;
     }
 
+    public void setConsumeMode(ConsumeMode consumeMode) {
+        this.consumeMode = consumeMode;
+    }
+
     public SelectorType getSelectorType() {
         return selectorType;
+    }
+
+    public void setSelectorType(SelectorType selectorType) {
+        this.selectorType = selectorType;
     }
 
     public void setSelectorExpression(String selectorExpression) {
@@ -239,6 +251,14 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
     public MessageModel getMessageModel() {
         return messageModel;
+    }
+
+    public void setMessageModel(MessageModel messageModel) {
+        this.messageModel = messageModel;
+    }
+
+    public void setConsumeTimeout(long consumeTimeout) {
+        this.consumeTimeout = consumeTimeout;
     }
 
     public DefaultMQPushConsumer getConsumer() {


### PR DESCRIPTION
## What is the purpose of the change
To support SpringBoot 1

## Brief changelog
1. Utilize registerBeanDefinition instead of registerBean when process listener container.
2. Add several setter methods of DefaultRocketMQListenerContainer to allow spring populate values.

## Verifying this change
1. When getBean method is invoked, we find that the values of the DefaultRocketMQListenerContainer are populated correctly.
