### PR TITLE
[ISSUE #285] Upgrade jackson/fastjson version

### DIFF
--- a/rocketmq-spring-boot-parent/pom.xml
+++ b/rocketmq-spring-boot-parent/pom.xml
@@ -42,7 +42,8 @@
 
         <rocketmq-version>4.7.1</rocketmq-version>
         <slf4j.version>1.7.25</slf4j.version>
-        <jackson.version>2.9.7</jackson.version>
+        <jackson.version>2.11.1</jackson.version>
+        <fastjson.version>1.2.72</fastjson.version>
 
         <java.version>1.8</java.version>
         <resource.delimiter>@</resource.delimiter>
@@ -160,6 +161,12 @@
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
                 <version>${jackson.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.alibaba</groupId>
+                <artifactId>fastjson</artifactId>
+                <version>${fastjson.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## What is the purpose of the change
1. To eliminate the vulnerability of the serialization components. [ISSUE #285  ]

## Brief changelog
1. Upgrade jackson version from 2.9.7 to 2.11.1
2. Upgrade fastjson version from 1.2.69 to 1.2.72

## Verifying this change
1. Jackson: https://help.aliyun.com/noticelist/articleid/1060035134.html
2. Fastjson: https://help.aliyun.com/noticelist/articleid/1060343604.html
