### PR TITLE
[ISSUE #306] Support real LitePullMessage in RocketMQ-Spring

### DIFF
--- a/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerACLApplication.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerACLApplication.java
@@ -40,6 +40,7 @@ public class ConsumerACLApplication implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+        ////This is an example of pull consumer with access-key and secret-key.
         List<String> messages = rocketMQTemplate.receive(String.class);
         System.out.printf("receive from rocketMQTemplate, messages=%s %n", messages);
     }

--- a/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/src/main/resources/application.properties
@@ -17,6 +17,8 @@
 spring.application.name=rocketmq-consume-acl-demo
 
 rocketmq.name-server=Endpoint_of_Aliware_MQ
+rocketmq.consumer.group=my-group1
+rocketmq.consumer.topic=test
 rocketmq.topic=normal_topic_define_in_Aliware_MQ
 
 # properties used in application code

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerApplication.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerApplication.java
@@ -43,9 +43,11 @@ public class ConsumerApplication implements CommandLineRunner {
 
     @Override
     public void run(String... args) throws Exception {
+        //This is an example of pull consumer using rocketMQTemplate.
         List<String> messages = rocketMQTemplate.receive(String.class);
         System.out.printf("receive from rocketMQTemplate, messages=%s %n", messages);
 
+        //This is an example of pull consumer using extRocketMQTemplate.
         messages = extRocketMQTemplate.receive(String.class);
         System.out.printf("receive from extRocketMQTemplate, messages=%s %n", messages);
     }

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerApplication.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ConsumerApplication.java
@@ -17,17 +17,37 @@
 
 package org.apache.rocketmq.samples.springboot;
 
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+import javax.annotation.Resource;
+import java.util.List;
 
 /**
  * ConsumerApplication
  */
 @SpringBootApplication
-public class ConsumerApplication {
+public class ConsumerApplication implements CommandLineRunner {
+
+    @Resource
+    private RocketMQTemplate rocketMQTemplate;
+
+    @Resource(name = "extRocketMQTemplate")
+    private RocketMQTemplate extRocketMQTemplate;
 
     public static void main(String[] args) {
         SpringApplication.run(ConsumerApplication.class, args);
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        List<String> messages = rocketMQTemplate.receive(String.class);
+        System.out.printf("receive from rocketMQTemplate, messages=%s %n", messages);
+
+        messages = extRocketMQTemplate.receive(String.class);
+        System.out.printf("receive from extRocketMQTemplate, messages=%s %n", messages);
     }
 }
 

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ExtRocketMQTemplate.java
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/java/org/apache/rocketmq/samples/springboot/ExtRocketMQTemplate.java
@@ -14,34 +14,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.samples.springboot;
 
+import org.apache.rocketmq.spring.annotation.ExtRocketMQConsumerConfiguration;
 import org.apache.rocketmq.spring.core.RocketMQTemplate;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import javax.annotation.Resource;
-import java.util.List;
-
-/**
- * ConsumerApplication
- */
-@SpringBootApplication
-public class ConsumerACLApplication implements CommandLineRunner {
-
-    @Resource
-    private RocketMQTemplate rocketMQTemplate;
-
-    public static void main(String[] args) {
-        SpringApplication.run(ConsumerACLApplication.class, args);
-    }
-
-    @Override
-    public void run(String... args) throws Exception {
-        List<String> messages = rocketMQTemplate.receive(String.class);
-        System.out.printf("receive from rocketMQTemplate, messages=%s %n", messages);
-    }
+@ExtRocketMQConsumerConfiguration(topic = "${demo.rocketmq.topic}", group = "string_consumer")
+public class ExtRocketMQTemplate extends RocketMQTemplate {
 }
-

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
@@ -16,6 +16,8 @@
 spring.application.name=rocketmq-consume-demo
 
 rocketmq.name-server=localhost:9876
+rocketmq.consumer.group=my-group1
+rocketmq.consumer.topic=test
 # properties used in application code
 demo.rocketmq.topic=string-topic
 demo.rocketmq.bytesRequestTopic=bytesRequestTopic

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQConsumerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQConsumerConfiguration.java
@@ -89,4 +89,9 @@ public @interface ExtRocketMQConsumerConfiguration {
      * The property of "secret-key".
      */
     String secretKey() default SECRET_KEY_PLACEHOLDER;
+
+    /**
+     * Maximum number of messages pulled each time.
+     */
+    int pullBatchSize() default 10;
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQConsumerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/ExtRocketMQConsumerConfiguration.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.annotation;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+public @interface ExtRocketMQConsumerConfiguration {
+
+    String NAME_SERVER_PLACEHOLDER = "${rocketmq.name-server:}";
+    String GROUP_PLACEHOLDER = "${rocketmq.consumer.group:}";
+    String TOPIC_PLACEHOLDER = "${rocketmq.consumer.topic:}";
+    String ACCESS_CHANNEL_PLACEHOLDER = "${rocketmq.access-channel:}";
+    String ACCESS_KEY_PLACEHOLDER = "${rocketmq.consumer.access-key:}";
+    String SECRET_KEY_PLACEHOLDER = "${rocketmq.consumer.secret-key:}";
+
+    /**
+     * The component name of the Producer configuration.
+     */
+    String value() default "";
+
+    /**
+     * The property of "name-server".
+     */
+    String nameServer() default NAME_SERVER_PLACEHOLDER;
+
+    /**
+     * The property of "access-channel".
+     */
+    String accessChannel() default ACCESS_CHANNEL_PLACEHOLDER;
+
+    /**
+     * Group name of consumer.
+     */
+    String group() default GROUP_PLACEHOLDER;
+
+    /**
+     * Topic name of consumer.
+     */
+    String topic() default TOPIC_PLACEHOLDER;
+
+    /**
+     * Control message mode, if you want all subscribers receive message all message, broadcasting is a good choice.
+     */
+    MessageModel messageModel() default MessageModel.CLUSTERING;
+
+    /**
+     * Control how to selector message.
+     *
+     * @see SelectorType
+     */
+    SelectorType selectorType() default SelectorType.TAG;
+
+    /**
+     * Control which message can be select. Grammar please see {@link SelectorType#TAG} and {@link SelectorType#SQL92}
+     */
+    String selectorExpression() default "*";
+
+    /**
+     * The property of "access-key".
+     */
+    String accessKey() default ACCESS_KEY_PLACEHOLDER;
+
+    /**
+     * The property of "secret-key".
+     */
+    String secretKey() default SECRET_KEY_PLACEHOLDER;
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.rocketmq.spring.autoconfigure;
+
+import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.spring.annotation.ExtRocketMQConsumerConfiguration;
+import org.apache.rocketmq.spring.annotation.MessageModel;
+import org.apache.rocketmq.spring.annotation.SelectorType;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
+import org.apache.rocketmq.spring.support.RocketMQUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.aop.framework.AopProxyUtils;
+import org.springframework.aop.scope.ScopedProxyUtils;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.support.BeanDefinitionValidationException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.support.GenericApplicationContext;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Configuration
+public class ExtConsumerResetConfiguration implements ApplicationContextAware, SmartInitializingSingleton {
+
+    private final static Logger log = LoggerFactory.getLogger(ExtConsumerResetConfiguration.class);
+
+    private ConfigurableApplicationContext applicationContext;
+
+    private StandardEnvironment environment;
+
+    private RocketMQProperties rocketMQProperties;
+
+    private RocketMQMessageConverter rocketMQMessageConverter;
+
+    public ExtConsumerResetConfiguration(RocketMQMessageConverter rocketMQMessageConverter,
+            StandardEnvironment environment, RocketMQProperties rocketMQProperties) {
+        this.rocketMQMessageConverter = rocketMQMessageConverter;
+        this.environment = environment;
+        this.rocketMQProperties = rocketMQProperties;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = (ConfigurableApplicationContext) applicationContext;
+    }
+
+    @Override
+    public void afterSingletonsInstantiated() {
+        Map<String, Object> beans = this.applicationContext
+                .getBeansWithAnnotation(ExtRocketMQConsumerConfiguration.class)
+                .entrySet().stream().filter(entry -> !ScopedProxyUtils.isScopedTarget(entry.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        beans.forEach(this::registerTemplate);
+    }
+
+    private void registerTemplate(String beanName, Object bean) {
+        Class<?> clazz = AopProxyUtils.ultimateTargetClass(bean);
+
+        if (!RocketMQTemplate.class.isAssignableFrom(bean.getClass())) {
+            throw new IllegalStateException(clazz + " is not instance of " + RocketMQTemplate.class.getName());
+        }
+
+        ExtRocketMQConsumerConfiguration annotation = clazz.getAnnotation(ExtRocketMQConsumerConfiguration.class);
+        GenericApplicationContext genericApplicationContext = (GenericApplicationContext) applicationContext;
+        validate(annotation, genericApplicationContext);
+
+        DefaultLitePullConsumer consumer = null;
+        try {
+            consumer = createConsumer(annotation);
+            // Set instanceName same as the beanName
+            consumer.setInstanceName(beanName);
+            consumer.start();
+        } catch (Exception e) {
+            log.error("Failed to startup PullConsumer for RocketMQTemplate {}", beanName, e);
+        }
+        RocketMQTemplate rocketMQTemplate = (RocketMQTemplate) bean;
+        rocketMQTemplate.setConsumer(consumer);
+        rocketMQTemplate.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
+        log.info("Set real consumer to :{} {}", beanName, annotation.value());
+    }
+
+    private DefaultLitePullConsumer createConsumer(ExtRocketMQConsumerConfiguration annotation)
+            throws MQClientException {
+
+        RocketMQProperties.Consumer consumerConfig = rocketMQProperties.getConsumer();
+        if (consumerConfig == null) {
+            consumerConfig = new RocketMQProperties.Consumer();
+        }
+        String nameServer = resolvePlaceholders(annotation.nameServer(), rocketMQProperties.getNameServer());
+        String groupName = resolvePlaceholders(annotation.group(), consumerConfig.getGroup());
+        String topicName = resolvePlaceholders(annotation.topic(), consumerConfig.getTopic());
+        Assert.hasText(nameServer, "[nameServer] must not be null");
+        Assert.hasText(groupName, "[group] must not be null");
+        Assert.hasText(topicName, "[topic] must not be null");
+
+        String accessChannel = resolvePlaceholders(annotation.accessChannel(), rocketMQProperties.getAccessChannel());
+        MessageModel messageModel = annotation.messageModel();
+        SelectorType selectorType = annotation.selectorType();
+        String selectorExpression = annotation.selectorExpression();
+        String ak = resolvePlaceholders(annotation.accessKey(), consumerConfig.getAccessKey());
+        String sk = resolvePlaceholders(annotation.secretKey(), consumerConfig.getSecretKey());
+
+        DefaultLitePullConsumer litePullConsumer = RocketMQUtil.createDefaultLitePullConsumer(nameServer,
+                accessChannel, groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk);
+        return litePullConsumer;
+    }
+
+    private String resolvePlaceholders(String text, String defaultValue) {
+        String value = environment.resolvePlaceholders(text);
+        return StringUtils.isEmpty(value) ? defaultValue : value;
+    }
+
+    private void validate(ExtRocketMQConsumerConfiguration annotation,
+            GenericApplicationContext genericApplicationContext) {
+        if (genericApplicationContext.isBeanNameInUse(annotation.value())) {
+            throw new BeanDefinitionValidationException(
+                    String.format("Bean {} has been used in Spring Application Context, " +
+                                    "please check the @ExtRocketMQConsumerConfiguration",
+                            annotation.value()));
+        }
+    }
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
@@ -125,9 +125,10 @@ public class ExtConsumerResetConfiguration implements ApplicationContextAware, S
         String selectorExpression = annotation.selectorExpression();
         String ak = resolvePlaceholders(annotation.accessKey(), consumerConfig.getAccessKey());
         String sk = resolvePlaceholders(annotation.secretKey(), consumerConfig.getSecretKey());
+        int pullBatchSize = annotation.pullBatchSize();
 
-        DefaultLitePullConsumer litePullConsumer = RocketMQUtil.createDefaultLitePullConsumer(nameServer,
-                accessChannel, groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk);
+        DefaultLitePullConsumer litePullConsumer = RocketMQUtil.createDefaultLitePullConsumer(nameServer, accessChannel,
+                groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk, pullBatchSize);
         return litePullConsumer;
     }
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -17,7 +17,6 @@
 
 package org.apache.rocketmq.spring.autoconfigure;
 
-import javax.annotation.PostConstruct;
 import org.apache.rocketmq.client.AccessChannel;
 import org.apache.rocketmq.client.MQAdmin;
 import org.apache.rocketmq.client.consumer.DefaultLitePullConsumer;
@@ -49,6 +48,8 @@ import org.springframework.context.annotation.Import;
 import org.springframework.core.env.Environment;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
 
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
@@ -137,9 +138,10 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
         String selectorExpression = consumerConfig.getSelectorExpression();
         String ak = consumerConfig.getAccessKey();
         String sk = consumerConfig.getSecretKey();
+        int pullBatchSize = consumerConfig.getPullBatchSize();
 
-        DefaultLitePullConsumer litePullConsumer = RocketMQUtil.createDefaultLitePullConsumer(nameServer,
-                accessChannel, groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk);
+        DefaultLitePullConsumer litePullConsumer = RocketMQUtil.createDefaultLitePullConsumer(nameServer, accessChannel,
+                groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk, pullBatchSize);
         return litePullConsumer;
     }
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
@@ -267,6 +267,11 @@ public class RocketMQProperties {
         private String secretKey;
 
         /**
+         * Maximum number of messages pulled each time.
+         */
+        private int pullBatchSize = 10;
+
+        /**
          * listener configuration container
          * the pattern is like this:
          * group1.topic1 = false
@@ -329,6 +334,14 @@ public class RocketMQProperties {
 
         public void setSecretKey(String secretKey) {
             this.secretKey = secretKey;
+        }
+
+        public int getPullBatchSize() {
+            return pullBatchSize;
+        }
+
+        public void setPullBatchSize(int pullBatchSize) {
+            this.pullBatchSize = pullBatchSize;
         }
 
         public Map<String, Map<String, Boolean>> getListeners() {

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQProperties.java
@@ -231,6 +231,42 @@ public class RocketMQProperties {
 
     public static final class Consumer {
         /**
+         * Group name of consumer.
+         */
+        private String group;
+
+        /**
+         * Topic name of consumer.
+         */
+        private String topic;
+
+        /**
+         * Control message mode, if you want all subscribers receive message all message, broadcasting is a good choice.
+         */
+        private String  messageModel = "CLUSTERING";
+
+        /**
+         * Control how to selector message.
+         *
+         */
+        private String selectorType = "TAG";
+
+        /**
+         * Control which message can be select.
+         */
+        private String selectorExpression = "*";
+
+        /**
+         * The property of "access-key".
+         */
+        private String accessKey;
+
+        /**
+         * The property of "secret-key".
+         */
+        private String secretKey;
+
+        /**
          * listener configuration container
          * the pattern is like this:
          * group1.topic1 = false
@@ -238,6 +274,62 @@ public class RocketMQProperties {
          * group3.topic3 = false
          */
         private Map<String, Map<String, Boolean>> listeners = new HashMap<>();
+
+        public String getGroup() {
+            return group;
+        }
+
+        public void setGroup(String group) {
+            this.group = group;
+        }
+
+        public String getTopic() {
+            return topic;
+        }
+
+        public void setTopic(String topic) {
+            this.topic = topic;
+        }
+
+        public String getMessageModel() {
+            return messageModel;
+        }
+
+        public void setMessageModel(String messageModel) {
+            this.messageModel = messageModel;
+        }
+
+        public String getSelectorType() {
+            return selectorType;
+        }
+
+        public void setSelectorType(String selectorType) {
+            this.selectorType = selectorType;
+        }
+
+        public String getSelectorExpression() {
+            return selectorExpression;
+        }
+
+        public void setSelectorExpression(String selectorExpression) {
+            this.selectorExpression = selectorExpression;
+        }
+
+        public String getAccessKey() {
+            return accessKey;
+        }
+
+        public void setAccessKey(String accessKey) {
+            this.accessKey = accessKey;
+        }
+
+        public String getSecretKey() {
+            return secretKey;
+        }
+
+        public void setSecretKey(String secretKey) {
+            this.secretKey = secretKey;
+        }
 
         public Map<String, Map<String, Boolean>> getListeners() {
             return listeners;

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
@@ -293,7 +293,7 @@ public class RocketMQUtil {
 
     public static DefaultLitePullConsumer createDefaultLitePullConsumer(String nameServer, String accessChannel,
             String groupName, String topicName, MessageModel messageModel, SelectorType selectorType,
-            String selectorExpression, String ak, String sk)
+            String selectorExpression, String ak, String sk, int pullBatchSize)
             throws MQClientException {
         DefaultLitePullConsumer litePullConsumer = null;
         if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
@@ -304,6 +304,7 @@ public class RocketMQUtil {
         }
         litePullConsumer.setNamesrvAddr(nameServer);
         litePullConsumer.setInstanceName(RocketMQUtil.getInstanceName(nameServer));
+        litePullConsumer.setPullBatchSize(pullBatchSize);
         if (accessChannel != null) {
             litePullConsumer.setAccessChannel(AccessChannel.valueOf(accessChannel));
         }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/ExtRocketMQTemplateTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/ExtRocketMQTemplateTest.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.spring.core;
 
 import javax.annotation.Resource;
 import org.apache.rocketmq.client.producer.TransactionMQProducer;
+import org.apache.rocketmq.spring.annotation.ExtRocketMQConsumerConfiguration;
 import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
 import org.apache.rocketmq.spring.annotation.RocketMQTransactionListener;
 import org.apache.rocketmq.spring.autoconfigure.RocketMQAutoConfiguration;
@@ -34,11 +35,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 @RunWith(SpringJUnit4ClassRunner.class)
 
 @SpringBootTest(properties = {
-    "rocketmq.nameServer=127.0.0.1:9876", "rocketmq.producer.group=extRocketMQTemplate-test-producer_group"}, classes = {RocketMQAutoConfiguration.class, ExtRocketMQTemplate.class, ExtTransactionListenerImpl.class})
+    "rocketmq.nameServer=127.0.0.1:9876", "rocketmq.producer.group=extRocketMQTemplate-test-producer_group"}, classes = {RocketMQAutoConfiguration.class, ExtRocketMQTemplate.class, ExtTransactionListenerImpl.class, ExtRocketMQConsumer.class})
 public class ExtRocketMQTemplateTest {
 
     @Resource(name = "extRocketMQTemplate")
     private RocketMQTemplate extRocketMQTemplate;
+
+    @Resource(name = "extRocketMQConsumer")
+    private ExtRocketMQConsumer extRocketMQConsumer;
 
     @Resource
     private RocketMQTemplate rocketMQTemplate;
@@ -49,6 +53,9 @@ public class ExtRocketMQTemplateTest {
         assertThat(extRocketMQTemplate.getProducer().getProducerGroup()).isEqualTo("extRocketMQTemplate-test-group");
         assertThat(extRocketMQTemplate.getProducer().getSendMsgTimeout()).isEqualTo(3000);
         assertThat(extRocketMQTemplate.getProducer().getMaxMessageSize()).isEqualTo(4 * 1024);
+
+        assertThat(extRocketMQConsumer.getConsumer().getNamesrvAddr()).isEqualTo("172.0.0.1:9876");
+        assertThat(extRocketMQConsumer.getConsumer().getConsumerGroup()).isEqualTo("extRocketMQTemplate-test-group");
     }
 
     @Test
@@ -91,6 +98,11 @@ class ExtTransactionListenerImpl implements RocketMQLocalTransactionListener {
     public RocketMQLocalTransactionState checkLocalTransaction(Message msg) {
         return RocketMQLocalTransactionState.COMMIT;
     }
+}
+
+@ExtRocketMQConsumerConfiguration(nameServer = "172.0.0.1:9876", group = "extRocketMQTemplate-test-group", topic = "test")
+class ExtRocketMQConsumer extends RocketMQTemplate {
+
 }
 
 

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/ExtRocketMQTemplateTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/ExtRocketMQTemplateTest.java
@@ -16,7 +16,6 @@
  */
 package org.apache.rocketmq.spring.core;
 
-import javax.annotation.Resource;
 import org.apache.rocketmq.client.producer.TransactionMQProducer;
 import org.apache.rocketmq.spring.annotation.ExtRocketMQConsumerConfiguration;
 import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
@@ -29,6 +28,8 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import javax.annotation.Resource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -56,6 +57,7 @@ public class ExtRocketMQTemplateTest {
 
         assertThat(extRocketMQConsumer.getConsumer().getNamesrvAddr()).isEqualTo("172.0.0.1:9876");
         assertThat(extRocketMQConsumer.getConsumer().getConsumerGroup()).isEqualTo("extRocketMQTemplate-test-group");
+        assertThat(extRocketMQConsumer.getConsumer().getPullBatchSize()).isEqualTo(3);
     }
 
     @Test
@@ -100,7 +102,7 @@ class ExtTransactionListenerImpl implements RocketMQLocalTransactionListener {
     }
 }
 
-@ExtRocketMQConsumerConfiguration(nameServer = "172.0.0.1:9876", group = "extRocketMQTemplate-test-group", topic = "test")
+@ExtRocketMQConsumerConfiguration(nameServer = "172.0.0.1:9876", group = "extRocketMQTemplate-test-group", topic = "test", pullBatchSize = 3)
 class ExtRocketMQConsumer extends RocketMQTemplate {
 
 }

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/RocketMQTemplateTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/core/RocketMQTemplateTest.java
@@ -50,7 +50,8 @@ import static org.mockito.ArgumentMatchers.any;
     "test.rocketmq.topic=test", "rocketmq.producer.access-key=test-ak",
     "rocketmq.producer.secret-key=test-sk", "rocketmq.accessChannel=LOCAL",
     "rocketmq.producer.sendMessageTimeout= 3500", "rocketmq.producer.retryTimesWhenSendFailed=3",
-    "rocketmq.producer.retryTimesWhenSendAsyncFailed=3"}, classes = {RocketMQAutoConfiguration.class, TransactionListenerImpl.class})
+    "rocketmq.producer.retryTimesWhenSendAsyncFailed=3",
+    "rocketmq.consumer.group=spring_rocketmq", "rocketmq.consumer.topic=test"}, classes = {RocketMQAutoConfiguration.class, TransactionListenerImpl.class})
 
 public class RocketMQTemplateTest {
     @Resource
@@ -89,6 +90,15 @@ public class RocketMQTemplateTest {
 
         try {
             rocketMQTemplate.syncSendOrderly(topic, "payload", "hashkey");
+        } catch (MessagingException e) {
+            assertThat(e).hasMessageContaining("org.apache.rocketmq.remoting.exception.RemotingConnectException: connect to [127.0.0.1:9876] failed");
+        }
+    }
+
+    @Test
+    public void testReceiveMessage() {
+        try {
+            rocketMQTemplate.receive(String.class);
         } catch (MessagingException e) {
             assertThat(e).hasMessageContaining("org.apache.rocketmq.remoting.exception.RemotingConnectException: connect to [127.0.0.1:9876] failed");
         }
@@ -234,6 +244,10 @@ public class RocketMQTemplateTest {
         assertThat(rocketMQTemplate.getProducer().getRetryTimesWhenSendAsyncFailed()).isEqualTo(3);
         assertThat(rocketMQTemplate.getProducer().getRetryTimesWhenSendFailed()).isEqualTo(3);
         assertThat(rocketMQTemplate.getProducer().getCompressMsgBodyOverHowmuch()).isEqualTo(1024 * 4);
+
+        assertThat(rocketMQTemplate.getConsumer().getNamesrvAddr()).isEqualTo("127.0.0.1:9876");
+        assertThat(rocketMQTemplate.getConsumer().getConsumerGroup()).isEqualTo("spring_rocketmq");
+        assertThat(rocketMQTemplate.getConsumer().getAccessChannel()).isEqualTo(AccessChannel.LOCAL);
     }
 
     @Test


### PR DESCRIPTION
## What is the purpose of the change

Support LitePullMessage in RocketMQ-Spring. 

Although I have seen a brother submit a PR for a similar function, I think that is not a real pull consumption model, it is no different from the push consumption model. I just focus on the issue, not the person.

## Brief changelog

An instance of DefaultLitePullConsumer is added to RocketMQTemplate, and the receive method of RocketMQTemplate can be called to consume messages in a pull mode.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
