### PR TITLE
[ISSUE #411] Support DELAY and WAIT properties  in RocketMQHeaders.java, which can convert Spring-Message to Rocket-Message conveniently

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQHeaders.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQHeaders.java
@@ -31,4 +31,6 @@ public class RocketMQHeaders {
     public static final String QUEUE_ID = "QUEUE_ID";
     public static final String SYS_FLAG = "SYS_FLAG";
     public static final String TRANSACTION_ID = "TRANSACTION_ID";
+    public static final String DELAY = "DELAY";
+    public static final String WAIT = "WAIT";
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
@@ -105,7 +105,9 @@ public class RocketMQUtil {
                 setHeader(toRocketHeaderKey(RocketMQHeaders.FLAG), message.getFlag()).
                 setHeader(toRocketHeaderKey(RocketMQHeaders.QUEUE_ID), message.getQueueId()).
                 setHeader(toRocketHeaderKey(RocketMQHeaders.SYS_FLAG), message.getSysFlag()).
-                setHeader(toRocketHeaderKey(RocketMQHeaders.TRANSACTION_ID), message.getTransactionId());
+                setHeader(toRocketHeaderKey(RocketMQHeaders.TRANSACTION_ID), message.getTransactionId()).
+                setHeader(toRocketHeaderKey(RocketMQHeaders.DELAY), message.getDelayTimeLevel()).
+                setHeader(toRocketHeaderKey(RocketMQHeaders.WAIT), message.isWaitStoreMsgOK());
         addUserProperties(message.getProperties(), messageBuilder);
         return messageBuilder.build();
     }


### PR DESCRIPTION
[ ISSUE #411 ]

## What is the purpose of the change

This change support DELAY and WAIT properties  in RocketMQHeaders.java, which can convert Spring-Message to Rocket-Message conveniently.

Because of losting properties of 'DELAY' and 'WAIT' in RocketMQHeaders.java. Without these properties, we will make mistakes when use RocketMQTemplate to send a DELAY-Message or a WAIT-Message.


## Brief changelog

Support DELAY and WAIT properties  in RocketMQHeaders.java, which can convert Spring-Message to Rocket-Message conveniently.