### PR TITLE
[ISSUE #429]The 'consumeThreadMax' in annotation @RocketMQMessageListener is not works well

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -22,6 +22,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.concurrent.LinkedBlockingQueue;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
@@ -72,8 +73,18 @@ public @interface RocketMQMessageListener {
 
     /**
      * Max consumer thread number.
+     * @deprecated This property is not work well, because the consumer thread pool executor use
+     * {@link LinkedBlockingQueue} with default capacity bound (Integer.MAX_VALUE), use
+     * {@link RocketMQMessageListener#consumeThreadNumber} .
+     * @see <a href="https://github.com/apache/rocketmq-spring/issues/429">issues#429</a>
      */
+    @Deprecated
     int consumeThreadMax() default 64;
+
+    /**
+     * consumer thread number.
+     */
+    int consumeThreadNumber() default 20;
 
     /**
      * Max re-consume times.

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -105,6 +105,8 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
 
     private int consumeThreadMax = 64;
 
+    private int consumeThreadNumber = 20;
+
     private String charset = "UTF-8";
 
     private MessageConverter messageConverter;
@@ -186,6 +188,10 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         return consumeThreadMax;
     }
 
+    public int getConsumeThreadNumber() {
+        return consumeThreadNumber;
+    }
+
     public String getCharset() {
         return charset;
     }
@@ -227,7 +233,8 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.rocketMQMessageListener = anno;
 
         this.consumeMode = anno.consumeMode();
-        this.consumeThreadMax = anno.consumeThreadMax();
+        this.consumeThreadMax = anno.consumeThreadNumber();
+        this.consumeThreadNumber = anno.consumeThreadNumber();
         this.messageModel = anno.messageModel();
         this.selectorType = anno.selectorType();
         this.selectorExpression = anno.selectorExpression();
@@ -612,10 +619,9 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         if (accessChannel != null) {
             consumer.setAccessChannel(accessChannel);
         }
-        consumer.setConsumeThreadMax(consumeThreadMax);
-        if (consumeThreadMax < consumer.getConsumeThreadMin()) {
-            consumer.setConsumeThreadMin(consumeThreadMax);
-        }
+        //set the consumer core thread number and maximum thread number has the same value
+        consumer.setConsumeThreadMax(consumeThreadNumber);
+        consumer.setConsumeThreadMin(consumeThreadNumber);
         consumer.setConsumeTimeout(consumeTimeout);
         consumer.setMaxReconsumeTimes(maxReconsumeTimes);
         switch (messageModel) {

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -244,7 +244,8 @@ public class DefaultRocketMQListenerContainerTest {
         container.setRocketMQMessageListener(anno);
 
         assertEquals(anno.consumeMode(), container.getConsumeMode());
-        assertEquals(anno.consumeThreadMax(), container.getConsumeThreadMax());
+        assertEquals(anno.consumeThreadNumber(), container.getConsumeThreadMax());
+        assertEquals(anno.consumeThreadNumber(), container.getConsumeThreadNumber());
         assertEquals(anno.messageModel(), container.getMessageModel());
         assertEquals(anno.selectorType(), container.getSelectorType());
         assertEquals(anno.selectorExpression(), container.getSelectorExpression());
@@ -256,7 +257,7 @@ public class DefaultRocketMQListenerContainerTest {
 
     @RocketMQMessageListener(consumerGroup = "abc1", topic = "test",
             consumeMode = ConsumeMode.ORDERLY,
-            consumeThreadMax = 3456,
+            consumeThreadNumber = 3456,
             messageModel = MessageModel.BROADCASTING,
             selectorType = SelectorType.SQL92,
             selectorExpression = "selectorExpression",


### PR DESCRIPTION
## What is the purpose of the change

Use 'consumeThreadNumber' instead of consumeThreadMax , so that the core thread number and max thread number of the consumer thread pool executor has the same thread number.

## Brief changelog

use consumeThreadNum to adjust consumeThreadMin and consumeThreadMax  at the same time .

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
