### PR TITLE
[ISSUE #424] Fix ext producer npe

### DIFF
--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Consumer.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Consumer.java
@@ -1,0 +1,31 @@
+package org.apache.rocketmq.samples.springboot.ext.producer;
+
+import org.apache.rocketmq.spring.annotation.RocketMQMessageListener;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.Resource;
+
+/**
+ * Class Name is Consumer
+ *
+ * @author LiJun
+ * Created on 2022/2/7 17:51
+ */
+@Service
+@RocketMQMessageListener(nameServer = "${demo.rocketmq.extNameServer}",
+        topic = "test_topic", consumerGroup = "test_group_c")
+public class Consumer implements RocketMQListener<String> {
+
+    @Resource
+    private Producer producer;
+
+    /**
+     * 模拟消费到消息马上发消息
+     */
+    @Override
+    public void onMessage(String message) {
+        System.out.println("consumer msg=" + message);
+        producer.sendMessage("C ->" + message);
+    }
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/ExtProducerHotfixMain.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/ExtProducerHotfixMain.java
@@ -1,0 +1,17 @@
+package org.apache.rocketmq.samples.springboot.ext.producer;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Class Name is ExtProducerHotfixMain
+ *
+ * @author LiJun
+ * Created on 2022/2/7 18:02
+ */
+@SpringBootApplication(scanBasePackages = "org.apache.rocketmq.samples.springboot.ext.producer")
+public class ExtProducerHotfixMain {
+    public static void main(String[] args) {
+        SpringApplication.run(ExtProducerHotfixMain.class, args);
+    }
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/MyExtRocketMQTemplate.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/MyExtRocketMQTemplate.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.samples.springboot.ext.producer;
+
+import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+
+@ExtRocketMQTemplateConfiguration(nameServer = "${demo.rocketmq.extNameServer}", group = "my-group2")
+public class MyExtRocketMQTemplate extends RocketMQTemplate {
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Producer.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Producer.java
@@ -1,0 +1,30 @@
+package org.apache.rocketmq.samples.springboot.ext.producer;
+
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.Resource;
+
+/**
+ * Class Name is Producer
+ *
+ * @author LiJun
+ * Created on 2022/2/7 17:49
+ */
+@Component
+public class Producer {
+
+    @Resource
+    private MyExtRocketMQTemplate template;
+
+    public void sendMessage(String msg) {
+        try {
+            System.out.println("send start message=" + msg + ", producer=" + template.getProducer());
+            template.send("test_topic", new GenericMessage<>(msg));
+            System.out.println("send end message=" + msg + ", producer=" + template.getProducer());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Task.java
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/java/org/apache/rocketmq/samples/springboot/ext/producer/Task.java
@@ -1,0 +1,29 @@
+package org.apache.rocketmq.samples.springboot.ext.producer;
+
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+/**
+ * Class Name is Task
+ *
+ * @author LiJun
+ * Created on 2022/2/7 17:54
+ */
+@Component
+public class Task {
+
+    @Resource
+    private Producer producer;
+
+    /**
+     * 模拟启动时 发消息 验证producer 是否为空
+     */
+    @PostConstruct
+    public void init() {
+        for (int i = 0; i < 100; i++) {
+            producer.sendMessage(i + "");
+        }
+    }
+}

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/src/test/resources/application.properties
@@ -1,0 +1,4 @@
+demo.rocketmq.extNameServer=127.0.0.1:9876
+rocketmq.name-server=localhost:9876
+rocketmq.producer.group=my-group1
+rocketmq.producer.sendMessageTimeout=300000

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
@@ -17,9 +17,6 @@
 
 package org.apache.rocketmq.spring.autoconfigure;
 
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.apache.rocketmq.client.exception.MQClientException;
 import org.apache.rocketmq.client.producer.DefaultMQProducer;
 import org.apache.rocketmq.spring.annotation.ExtRocketMQTemplateConfiguration;
 import org.apache.rocketmq.spring.core.RocketMQTemplate;
@@ -30,7 +27,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.aop.framework.AopProxyUtils;
 import org.springframework.aop.scope.ScopedProxyUtils;
 import org.springframework.beans.BeansException;
-import org.springframework.beans.factory.SmartInitializingSingleton;
+import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.beans.factory.support.BeanDefinitionValidationException;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
@@ -41,7 +38,7 @@ import org.springframework.core.env.StandardEnvironment;
 import org.springframework.util.StringUtils;
 
 @Configuration
-public class ExtProducerResetConfiguration implements ApplicationContextAware, SmartInitializingSingleton {
+public class ExtProducerResetConfiguration implements ApplicationContextAware, BeanPostProcessor {
     private final static Logger log = LoggerFactory.getLogger(ExtProducerResetConfiguration.class);
 
     private ConfigurableApplicationContext applicationContext;
@@ -53,7 +50,7 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
     private RocketMQMessageConverter rocketMQMessageConverter;
 
     public ExtProducerResetConfiguration(RocketMQMessageConverter rocketMQMessageConverter,
-        StandardEnvironment environment, RocketMQProperties rocketMQProperties) {
+            StandardEnvironment environment, RocketMQProperties rocketMQProperties) {
         this.rocketMQMessageConverter = rocketMQMessageConverter;
         this.environment = environment;
         this.rocketMQProperties = rocketMQProperties;
@@ -65,12 +62,13 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
     }
 
     @Override
-    public void afterSingletonsInstantiated() {
-        Map<String, Object> beans = this.applicationContext.getBeansWithAnnotation(ExtRocketMQTemplateConfiguration.class)
-            .entrySet().stream().filter(entry -> !ScopedProxyUtils.isScopedTarget(entry.getKey()))
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-        beans.forEach(this::registerTemplate);
+    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        Class<?> clazz = AopProxyUtils.ultimateTargetClass(bean);
+        if (clazz.isAnnotationPresent(ExtRocketMQTemplateConfiguration.class)
+                && !ScopedProxyUtils.isScopedTarget(beanName)) {
+            this.registerTemplate(beanName, bean);
+        }
+        return BeanPostProcessor.super.postProcessBeforeInitialization(bean, beanName);
     }
 
     private void registerTemplate(String beanName, Object bean) {
@@ -87,12 +85,13 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
         DefaultMQProducer mqProducer = createProducer(annotation);
         // Set instanceName same as the beanName
         mqProducer.setInstanceName(beanName);
-        try {
-            mqProducer.start();
-        } catch (MQClientException e) {
-            throw new BeanDefinitionValidationException(String.format("Failed to startup MQProducer for RocketMQTemplate {}",
-                beanName), e);
-        }
+        // rocketmqTempalte afterProperties 会启动
+        // try {
+        //     mqProducer.start();
+        // } catch (MQClientException e) {
+        //     throw new BeanDefinitionValidationException(String.format("Failed to startup MQProducer for RocketMQTemplate {}",
+        //         beanName), e);
+        // }
         RocketMQTemplate rocketMQTemplate = (RocketMQTemplate) bean;
         rocketMQTemplate.setProducer(mqProducer);
         rocketMQTemplate.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
@@ -134,11 +133,11 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
     }
 
     private void validate(ExtRocketMQTemplateConfiguration annotation,
-        GenericApplicationContext genericApplicationContext) {
+            GenericApplicationContext genericApplicationContext) {
         if (genericApplicationContext.isBeanNameInUse(annotation.value())) {
             throw new BeanDefinitionValidationException(String.format("Bean {} has been used in Spring Application Context, " +
-                    "please check the @ExtRocketMQTemplateConfiguration",
-                annotation.value()));
+                            "please check the @ExtRocketMQTemplateConfiguration",
+                    annotation.value()));
         }
     }
 }


### PR DESCRIPTION
## What is the purpose of the change
Fix ext producer npe
# 修改的地方
调整ExtProducerResetConfiguration实现BeanPostProcessor 将DefaultMQProducer的完善提前至beanpost过程
防止consumer先启动后或以及其他bean初始化完后，立马用ExtRocketMQTemplate发消息 producer 为空问题
