### PR TITLE
[ISSUE #450] Add log about creation of default litePullConsumer

### DIFF
--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties
@@ -16,7 +16,9 @@
 spring.application.name=rocketmq-consume-demo
 
 rocketmq.name-server=localhost:9876
+# Default LitePullConsumer group. Comment out this property if you don't want the default LitePullConsumer.
 rocketmq.consumer.group=my-group1
+# Default LitePullConsumer topic. Comment out this property if you don't want the default LitePullConsumer.
 rocketmq.consumer.topic=test
 # properties used in application code
 demo.rocketmq.topic=string-topic

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -147,6 +147,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
         litePullConsumer.setEnableMsgTrace(consumerConfig.isEnableMsgTrace());
         litePullConsumer.setCustomizedTraceTopic(consumerConfig.getCustomizedTraceTopic());
         litePullConsumer.setNamespace(consumerConfig.getNamespace());
+        log.info("Default lite pull consumer to topic {} in group {} has been created.", consumerConfig.getTopic(), consumerConfig.getGroup());
         return litePullConsumer;
     }
 


### PR DESCRIPTION
## What is the purpose of the change

This is a fix of [ISSUE #450 ]

## Brief changelog

1. Add an INFO level log in method org.apache.rocketmq.client.consumer.DefaultLitePullConsumer() when the consumer is created.
2. Add comments about usage of properties _rocketmq.consumer.group_ and _rocketmq.consumer.topic_  in rocketmq-spring-boot-samples/rocketmq-consume-demo/src/main/resources/application.properties

## Verifying this change
An INFO level log like this "Default lite pull consumer to topic my-topic in group my-group has been created." is printed when the Spring application is started with _rocketmq.consumer.group_ and _rocketmq.consumer.topic_  are set.

