### PR TITLE
[ISSUE #494]Replace deprecated StringUtils.isEmpty method with StringUtils.hasLength

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtConsumerResetConfiguration.java
@@ -138,7 +138,7 @@ public class ExtConsumerResetConfiguration implements ApplicationContextAware, S
 
     private String resolvePlaceholders(String text, String defaultValue) {
         String value = environment.resolvePlaceholders(text);
-        return StringUtils.isEmpty(value) ? defaultValue : value;
+        return StringUtils.hasLength(value) ? value : defaultValue;
     }
 
     private void validate(ExtRocketMQConsumerConfiguration annotation,

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ExtProducerResetConfiguration.java
@@ -105,15 +105,15 @@ public class ExtProducerResetConfiguration implements ApplicationContextAware, S
         }
         String nameServer = environment.resolvePlaceholders(annotation.nameServer());
         String groupName = environment.resolvePlaceholders(annotation.group());
-        groupName = StringUtils.isEmpty(groupName) ? producerConfig.getGroup() : groupName;
+        groupName = !StringUtils.hasLength(groupName) ? producerConfig.getGroup() : groupName;
 
         String ak = environment.resolvePlaceholders(annotation.accessKey());
-        ak = StringUtils.isEmpty(ak) ? producerConfig.getAccessKey() : ak;
+        ak = StringUtils.hasLength(ak) ? ak : producerConfig.getAccessKey();
         String sk = environment.resolvePlaceholders(annotation.secretKey());
-        sk = StringUtils.isEmpty(sk) ? producerConfig.getSecretKey() : sk;
+        sk = StringUtils.hasLength(sk) ? sk : producerConfig.getSecretKey();
         boolean isEnableMsgTrace = annotation.enableMsgTrace();
         String customizedTraceTopic = environment.resolvePlaceholders(annotation.customizedTraceTopic());
-        customizedTraceTopic = StringUtils.isEmpty(customizedTraceTopic) ? producerConfig.getCustomizedTraceTopic() : customizedTraceTopic;
+        customizedTraceTopic = StringUtils.hasLength(customizedTraceTopic) ? customizedTraceTopic : producerConfig.getCustomizedTraceTopic();
         //if String is not is equal "true" TLS mode will represent the as default value false
         boolean useTLS = new Boolean(environment.resolvePlaceholders(annotation.tlsEnable()));
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/ListenerContainerConfiguration.java
@@ -120,15 +120,15 @@ public class ListenerContainerConfiguration implements ApplicationContextAware {
         container.setRocketMQMessageListener(annotation);
 
         String nameServer = environment.resolvePlaceholders(annotation.nameServer());
-        nameServer = StringUtils.isEmpty(nameServer) ? rocketMQProperties.getNameServer() : nameServer;
+        nameServer = StringUtils.hasLength(nameServer) ? nameServer : rocketMQProperties.getNameServer();
         String accessChannel = environment.resolvePlaceholders(annotation.accessChannel());
         container.setNameServer(nameServer);
-        if (!StringUtils.isEmpty(accessChannel)) {
+        if (StringUtils.hasLength(accessChannel)) {
             container.setAccessChannel(AccessChannel.valueOf(accessChannel));
         }
         container.setTopic(environment.resolvePlaceholders(annotation.topic()));
         String tags = environment.resolvePlaceholders(annotation.selectorExpression());
-        if (!StringUtils.isEmpty(tags)) {
+        if (StringUtils.hasLength(tags)) {
             container.setSelectorExpression(tags);
         }
         container.setConsumerGroup(environment.resolvePlaceholders(annotation.consumerGroup()));

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -106,7 +106,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
         DefaultMQProducer producer = RocketMQUtil.createDefaultMQProducer(groupName, ak, sk, isEnableMsgTrace, customizedTraceTopic);
 
         producer.setNamesrvAddr(nameServer);
-        if (!StringUtils.isEmpty(accessChannel)) {
+        if (StringUtils.hasLength(accessChannel)) {
             producer.setAccessChannel(AccessChannel.valueOf(accessChannel));
         }
         producer.setSendMsgTimeout(producerConfig.getSendMessageTimeout());

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQUtil.java
@@ -17,6 +17,10 @@
 package org.apache.rocketmq.spring.support;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.lang.reflect.Field;
+import java.nio.charset.Charset;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.rocketmq.acl.common.AclClientRPCHook;
 import org.apache.rocketmq.acl.common.SessionCredentials;
 import org.apache.rocketmq.client.AccessChannel;
@@ -46,12 +50,8 @@ import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.converter.MessageConverter;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
-
-import java.lang.reflect.Field;
-import java.nio.charset.Charset;
-import java.util.Map;
-import java.util.Objects;
 
 public class RocketMQUtil {
     private final static Logger log = LoggerFactory.getLogger(RocketMQUtil.class);
@@ -179,10 +179,10 @@ public class RocketMQUtil {
         if (Objects.nonNull(headers) && !headers.isEmpty()) {
             Object keys = headers.get(RocketMQHeaders.KEYS);
             // if headers not have 'KEYS', try add prefix when getting keys
-            if (StringUtils.isEmpty(keys)) {
+            if (ObjectUtils.isEmpty(keys)) {
                 keys = headers.get(toRocketHeaderKey(RocketMQHeaders.KEYS));
             }
-            if (!StringUtils.isEmpty(keys)) { // if headers has 'KEYS', set rocketMQ message key
+            if (!ObjectUtils.isEmpty(keys)) { // if headers has 'KEYS', set rocketMQ message key
                 rocketMsg.setKeys(keys.toString());
             }
             Object flagObj = headers.getOrDefault("FLAG", "0");
@@ -249,7 +249,7 @@ public class RocketMQUtil {
             ak = null;
             sk = null;
         }
-        if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
+        if (StringUtils.hasLength(ak) && StringUtils.hasLength(sk)) {
             return new AclClientRPCHook(new SessionCredentials(ak, sk));
         }
         return null;
@@ -258,7 +258,7 @@ public class RocketMQUtil {
     public static DefaultMQProducer createDefaultMQProducer(String groupName, String ak, String sk,
         boolean isEnableMsgTrace, String customizedTraceTopic) {
 
-        boolean isEnableAcl = !StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk);
+        boolean isEnableAcl = StringUtils.hasLength(ak) && StringUtils.hasLength(sk);
         DefaultMQProducer producer;
         if (isEnableAcl) {
             producer = new TransactionMQProducer(groupName, new AclClientRPCHook(new SessionCredentials(ak, sk)));
@@ -289,7 +289,7 @@ public class RocketMQUtil {
             String selectorExpression, String ak, String sk, int pullBatchSize, boolean useTLS)
             throws MQClientException {
         DefaultLitePullConsumer litePullConsumer = null;
-        if (!StringUtils.isEmpty(ak) && !StringUtils.isEmpty(sk)) {
+        if (StringUtils.hasLength(ak) && StringUtils.hasLength(sk)) {
             litePullConsumer = new DefaultLitePullConsumer(groupName, new AclClientRPCHook(new SessionCredentials(ak, sk)));
             litePullConsumer.setVipChannelEnabled(false);
         } else {


### PR DESCRIPTION
## What is the purpose of the change

close #494 

## Brief changelog

- Replace deprecated StringUtils.isEmpty method with StringUtils.hasLength

## Verifying this change

XXXX

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
