### PR TITLE
[ISSUE #546] Fix ConsumeMessageService#updateCorePoolSize" not support increase co…

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -18,13 +18,11 @@
 package org.apache.rocketmq.spring.annotation;
 
 import org.apache.rocketmq.client.impl.consumer.ConsumeMessageService;
-
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import java.util.concurrent.LinkedBlockingQueue;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListener.java
@@ -17,6 +17,8 @@
 
 package org.apache.rocketmq.spring.annotation;
 
+import org.apache.rocketmq.client.impl.consumer.ConsumeMessageService;
+
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
@@ -73,12 +75,10 @@ public @interface RocketMQMessageListener {
 
     /**
      * Max consumer thread number.
-     * @deprecated This property is not work well, because the consumer thread pool executor use
-     * {@link LinkedBlockingQueue} with default capacity bound (Integer.MAX_VALUE), use
-     * {@link RocketMQMessageListener#consumeThreadNumber} .
-     * @see <a href="https://github.com/apache/rocketmq-spring/issues/429">issues#429</a>
+     * This property control consumer thread pool executor maximumPoolSize see
+     * {@link ConsumeMessageService#updateCorePoolSize(int)}
+     * @see <a href="https://github.com/apache/rocketmq-spring/issues/546">issues#546</a>
      */
-    @Deprecated
     int consumeThreadMax() default 64;
 
     /**

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -236,7 +236,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         this.rocketMQMessageListener = anno;
 
         this.consumeMode = anno.consumeMode();
-        this.consumeThreadMax = anno.consumeThreadNumber();
+        this.consumeThreadMax = anno.consumeThreadMax();
         this.consumeThreadNumber = anno.consumeThreadNumber();
         this.messageModel = anno.messageModel();
         this.selectorType = anno.selectorType();
@@ -641,8 +641,8 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         if (accessChannel != null) {
             consumer.setAccessChannel(accessChannel);
         }
-        //set the consumer core thread number and maximum thread number has the same value
-        consumer.setConsumeThreadMax(consumeThreadNumber);
+
+        consumer.setConsumeThreadMax(consumeThreadMax);
         consumer.setConsumeThreadMin(consumeThreadNumber);
         consumer.setConsumeTimeout(consumeTimeout);
         consumer.setMaxReconsumeTimes(maxReconsumeTimes);

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainerTest.java
@@ -244,7 +244,7 @@ public class DefaultRocketMQListenerContainerTest {
         container.setRocketMQMessageListener(anno);
 
         assertEquals(anno.consumeMode(), container.getConsumeMode());
-        assertEquals(anno.consumeThreadNumber(), container.getConsumeThreadMax());
+        assertEquals(anno.consumeThreadMax(), container.getConsumeThreadMax());
         assertEquals(anno.consumeThreadNumber(), container.getConsumeThreadNumber());
         assertEquals(anno.messageModel(), container.getMessageModel());
         assertEquals(anno.selectorType(), container.getSelectorType());


### PR DESCRIPTION
Fix: #546 
## What is the purpose of the change

 makes method "ConsumeMessageService#updateCorePoolSize" support increase coreSize.

## Brief changelog

use field RocketMQMessageListener#consumeThreadNumber as consumeExecutor coreSize, consumeThreadMax as consumeExecutor maximumSize.

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
