### PR TITLE
Resolving consumer beans from CGLIB proxy classes created by @Configuration

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListenerBeanPostProcessor.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/annotation/RocketMQMessageListenerBeanPostProcessor.java
@@ -48,7 +48,7 @@ public class RocketMQMessageListenerBeanPostProcessor implements ApplicationCont
     @Override
     public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
         Class<?> targetClass = AopUtils.getTargetClass(bean);
-        RocketMQMessageListener ann = targetClass.getAnnotation(RocketMQMessageListener.class);
+        RocketMQMessageListener ann = AnnotationUtils.findAnnotation(targetClass, RocketMQMessageListener.class);
         if (ann != null) {
             RocketMQMessageListener enhance = enhance(targetClass, ann);
             if (listenerContainerConfiguration != null) {


### PR DESCRIPTION
## What is the purpose of the change
Originally, when annotating a class with @Configuration, it couldn't be resolved as a RocketMQ consumer listener class. I changed the way annotations are parsed, allowing classes marked with @Configuration to be correctly identified as RocketMQ consumer listener classes. This is because, in our practice at the company, many people also prefer using @Configuration.
## Brief changelog
In the postProcessAfterInitialization() method of the RocketMQMessageListenerBeanPostProcessor message listener post-processor, I changed the annotation processing approach to:
RocketMQMessageListener ann = (RocketMQMessageListener) AnnotationUtils.findAnnotation(targetClass, RocketMQMessageListener.class);
This modification allows both @Configuration and @Service annotated classes to function as consumer listeners.
## Verifying this change
In production and actively deployed.
RocketMQMessageListener ann = AnnotationUtils.findAnnotation(targetClass, RocketMQMessageListener.class);
