### PR TITLE
Fix the issue of sending message "No route information of this topic: xxx" when the producer does not configure the namespace

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -115,7 +115,9 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
         producer.setCompressMsgBodyOverHowmuch(producerConfig.getCompressMessageBodyThreshold());
         producer.setRetryAnotherBrokerWhenNotStoreOK(producerConfig.isRetryNextServer());
         producer.setUseTLS(producerConfig.isTlsEnable());
-        producer.setNamespace(producerConfig.getNamespace());
+        if (StringUtils.hasText(producerConfig.getNamespace())) {
+            producer.setNamespace(producerConfig.getNamespace());
+        }
         producer.setInstanceName(producerConfig.getInstanceName());
         log.info("a producer ({}) init on namesrv {}",  groupName, nameServer);
         return producer;
@@ -147,7 +149,9 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
                 groupName, topicName, messageModel, selectorType, selectorExpression, ak, sk, pullBatchSize, useTLS);
         litePullConsumer.setEnableMsgTrace(consumerConfig.isEnableMsgTrace());
         litePullConsumer.setCustomizedTraceTopic(consumerConfig.getCustomizedTraceTopic());
-        litePullConsumer.setNamespace(consumerConfig.getNamespace());
+        if (StringUtils.hasText(consumerConfig.getNamespace())) {
+            litePullConsumer.setNamespace(consumerConfig.getNamespace());
+        }
         litePullConsumer.setInstanceName(consumerConfig.getInstanceName());
         log.info("a pull consumer({} sub {}) init on namesrv {}",  groupName, topicName, nameServer);
         return litePullConsumer;


### PR DESCRIPTION
## What is the purpose of the change

Solve the problem of sending message errors when producers do not configure namespaces。

In the current situation, when the namespace is not configured, the method of setting the namespace is called when instantiating the bean, causing the producer to initialize the namespace to be empty, but 'ClientConfig # namespaceInitialized' is set to true. This leads to the producer sending an error message: "No route information of this topic: xxx"

## Brief changelog

When instantiating beans ("defaultMQProducer", "defaultLitePullConsumer"), the set namespace method is called only when the namespace is configured。



## Verifying this change

Verified！

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [ ] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [ ] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. 
- [ ] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
