### PR TITLE
[ISSUE #632 ] Fix NPE caused by using @ ExtRocketMQTemplateConfiguration annotation extension to send messages in v5

### DIFF
--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/annotation/RocketMQMessageListenerBeanPostProcessor.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/annotation/RocketMQMessageListenerBeanPostProcessor.java
@@ -23,6 +23,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.SmartLifecycle;
 import org.springframework.core.OrderComparator;
 import org.springframework.core.annotation.AnnotationUtils;
 
@@ -32,13 +33,15 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
-public class RocketMQMessageListenerBeanPostProcessor implements ApplicationContextAware, BeanPostProcessor, InitializingBean {
+public class RocketMQMessageListenerBeanPostProcessor implements ApplicationContextAware, BeanPostProcessor, InitializingBean, SmartLifecycle {
 
     private ApplicationContext applicationContext;
 
     private AnnotationEnhancer enhancer;
 
     private ListenerContainerConfiguration listenerContainerConfiguration;
+
+    private boolean running = false;
 
     @Override
     public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
@@ -56,6 +59,34 @@ public class RocketMQMessageListenerBeanPostProcessor implements ApplicationCont
             }
         }
         return bean;
+    }
+
+    @Override
+    public int getPhase() {
+        return Integer.MAX_VALUE - 2000;
+    }
+
+    @Override
+    public void start() {
+        if (!isRunning()) {
+            this.setRunning(true);
+            listenerContainerConfiguration.startContainer();
+        }
+    }
+
+    @Override
+    public void stop() {
+
+    }
+
+    public void setRunning(boolean running) {
+        this.running = running;
+    }
+
+
+    @Override
+    public boolean isRunning() {
+        return running;
     }
 
     @Override


### PR DESCRIPTION
## What is the purpose of the change

fix and close [ISSUE #632  ]

fix v5 client [ISSUE #632  ]

## Brief changelog

问题现象：
  修复应用启动时，监听RocketMQ消息后使用@ExtRocketMQTemplateConfiguration注解扩展的RocketMQTemplate发送消息导致的空指针异常问题。
问题原因：
  Listener 启动时机比 @ExtRocketMQTemplateConfiguration注解扩展的RocketMQTemplate中producer 实例化的早，导致Listener监听到消息时 RocketMQTemplate中producerBuilder 还未实例化，使用RocketMQTemplate 发送消息将调用 getProducer() 方法获取  producer [  this.producer =  producerBuilder.build() ]，此时producerBuilder 等于null 将导致空指针异常。

（@RocketMQMessageListener 与 Spring Cloud Stream 的生产者一起使用时同样存在一样的问题，都是因为Listener的启动时机太早）
解决方案：
推迟了Listener 的启动时机 详情见commits。

