### PR TITLE
[ISSUE #656] Set rocketmq-v5-client-spring-boot default awaitDuration to 5

### DIFF
--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/annotation/ExtConsumerResetConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/annotation/ExtConsumerResetConfiguration.java
@@ -85,6 +85,6 @@ public @interface ExtConsumerResetConfiguration {
     /**
      * The max await time when receive messages from the server.
      */
-    int awaitDuration() default 0;
+    int awaitDuration() default 5;
 
 }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQProperties.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQProperties.java
@@ -173,7 +173,7 @@ public class RocketMQProperties {
         /**
          * The max await time when receive messages from the server.
          */
-        private int awaitDuration = 0;
+        private int awaitDuration = 5;
 
         /**
          * Tag of consumer.


### PR DESCRIPTION
## What is the purpose of the change

Set rocketmq-v5-client-spring-boot default awaitDuration to 5

## Brief changelog

Set rocketmq-v5-client-spring-boot default awaitDuration to 5 from 0
