### PR TITLE
Update DefaultRocketMQListenerContainer#getMessageType to protected

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/DefaultRocketMQListenerContainer.java
@@ -576,7 +576,7 @@ public class DefaultRocketMQListenerContainer implements InitializingBean,
         }
     }
 
-    private Type getMessageType() {
+    protected Type getMessageType() {
         Class<?> targetClass;
         if (rocketMQListener != null) {
             targetClass = AopProxyUtils.ultimateTargetClass(rocketMQListener);


### PR DESCRIPTION
## What is the purpose of the change

```
public interface IMessageConsumer<T> extends RocketMQListener<T> {
}
```

![image](https://github.com/apache/rocketmq-spring/assets/24709538/8308c1a0-022d-4a3a-848c-5a9d9c22e877)


Due to project needs, some personalized business operations need to extend the `RocketMQListener` interface.
I need to override the `DefaultRocketMQListenerContainer#getMessageType()` method to complete my custom extension.
