### PR TITLE
Updated the RocketMQ version dependencies in the rocketmq-spring-boot-samples and rocketmq-v5-client-spring-boot-samples modules.

### DIFF
--- a/rocketmq-spring-boot-samples/pom.xml
+++ b/rocketmq-spring-boot-samples/pom.xml
@@ -24,7 +24,7 @@
     <groupId>org.apache.rocketmq</groupId>
     <artifactId>rocketmq-spring-boot-samples</artifactId>
     <packaging>pom</packaging>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.3.2-SNAPSHOT</version>
     
     <name>RocketMQ Spring Boot Samples</name>
     <description>Samples for RocketMQ Spring Boot</description>

--- a/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-acl-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     
     <artifactId>rocketmq-consume-acl-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-consume-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-consume-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     
     <artifactId>rocketmq-consume-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-consumer-pull-simple-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-consumer-pull-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-consumer-pull-simple-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-consumer-push-simple-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-consumer-push-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-consumer-push-simple-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-produce-acl-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-acl-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-produce-acl-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-produce-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-produce-demo/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-produce-demo</artifactId>

--- a/rocketmq-spring-boot-samples/rocketmq-producer-simple-demo/pom.xml
+++ b/rocketmq-spring-boot-samples/rocketmq-producer-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-producer-simple-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/pom.xml
@@ -22,7 +22,7 @@
 	<groupId>org.apache.rocketmq</groupId>
 	<artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
 	<packaging>pom</packaging>
-	<version>2.3.1-SNAPSHOT</version>
+	<version>2.3.2-SNAPSHOT</version>
 
 	<name>rocketmq-v5-client-spring-boot-samples</name>
 	<description>rocketmq-v5-client-spring-boot-samples</description>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consume-acl-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consume-acl-demo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
     <artifactId>rocketmq-v5-client-consume-acl-demo</artifactId>
 

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consume-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consume-demo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-consume-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consumer-push-simple-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consumer-push-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-consumer-push-simple-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consumer-simple-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-consumer-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-consumer-simple-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-acl-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-acl-demo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-producer-acl-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-demo/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-producer-demo</artifactId>

--- a/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-simple-demo/pom.xml
+++ b/rocketmq-v5-client-spring-boot-samples/rocketmq-v5-client-producer-simple-demo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.rocketmq</groupId>
         <artifactId>rocketmq-v5-client-spring-boot-samples</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.3.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>rocketmq-v5-client-producer-simple-demo</artifactId>


### PR DESCRIPTION
## What is the purpose of the change

Updated the RocketMQ version dependencies in the rocketmq-spring-boot-samples and rocketmq-v5-client-spring-boot-samples modules.

## Brief changelog

- Updated RocketMQ version in rocketmq-spring-boot-samples module
- Updated RocketMQ version in rocketmq-v5-client-spring-boot-samples module

Updated version from 2.3.1-SNAPSHOT to 2.3.2-SNAPSHOT