### PR TITLE
update remoting client version to 5.3.2 to support go-away

### DIFF
--- a/rocketmq-spring-boot-parent/pom.xml
+++ b/rocketmq-spring-boot-parent/pom.xml
@@ -42,7 +42,7 @@
 
         <rocketmq.spring.boot.version>2.3.4-SNAPSHOT</rocketmq.spring.boot.version>
 
-        <rocketmq.version>5.3.1</rocketmq.version>
+        <rocketmq.version>5.3.2</rocketmq.version>
         <slf4j.version>1.7.25</slf4j.version>
         <jackson.version>2.11.1</jackson.version>
         <fastjson.version>1.2.83</fastjson.version>


### PR DESCRIPTION

update remoting client version to 5.3.2 to support go-away