### PR TITLE
[ISSUE #685] In rocketmq-v5-client-spring-boot-starter, configuring multiple topics is not supported.

### DIFF
--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/ExtTemplateResetConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/ExtTemplateResetConfiguration.java
@@ -114,10 +114,9 @@ public class ExtTemplateResetConfiguration implements ApplicationContextAware, S
         ClientConfiguration clientConfiguration = RocketMQUtil.createClientConfiguration(accessKey, secretKey,
             endpoints, Duration.ofSeconds(requestTimeout), sslEnabled, namespace);
         final ClientServiceProvider provider = ClientServiceProvider.loadService();
-        ProducerBuilder producerBuilder = provider.newProducerBuilder()
+        return provider.newProducerBuilder()
                 .setClientConfiguration(clientConfiguration).setMaxAttempts(annotation.maxAttempts())
-                .setTopics(topic);
-        return producerBuilder;
+                .setTopics(topic.split(RocketMQAutoConfiguration.COMMA));
     }
 
 }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQAutoConfiguration.java
@@ -59,6 +59,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
     public static final String ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME = "rocketMQClientTemplate";
     public static final String PRODUCER_BUILDER_BEAN_NAME = "producerBuilder";
     public static final String SIMPLE_CONSUMER_BUILDER_BEAN_NAME = "simpleConsumerBuilder";
+    public static final String COMMA = ",";
     private ApplicationContext applicationContext;
 
     @Override
@@ -87,7 +88,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
         if (StringUtils.hasLength(topic)) {
             // Set the topic name(s), which is optional but recommended. It makes producer could prefetch the topic
             // route before message publishing.
-            producerBuilder.setTopics(rocketMQProducer.getTopic());
+            producerBuilder.setTopics(rocketMQProducer.getTopic().split(COMMA));
         }
         log.info(String.format("a producer init on proxy %s", endPoints));
         return producerBuilder;


### PR DESCRIPTION
fix topics