### PR TITLE
[ISSUE #583]: 新增 扩展点用于实现链路追踪

### DIFF
--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/MessagePostProcessorConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/MessagePostProcessorConfiguration.java
@@ -14,22 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.rocketmq.spring.autoconfigure;
 
-import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
-import org.apache.rocketmq.spring.support.RocketMQMessageHandler;
-import org.apache.rocketmq.spring.support.RocketMQMessageListenerContainerRegistrar;
+
+import org.apache.rocketmq.spring.support.RocketMQMessagePostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.ConfigurableEnvironment;
 
+/**
+ * @see RocketMQMessagePostProcessor
+ */
 @Configuration
-@ConditionalOnMissingBean(RocketMQMessageListenerContainerRegistrar.class)
-public class ListenerContainerConfiguration {
+@ConditionalOnMissingBean(RocketMQMessagePostProcessor.class)
+class MessagePostProcessorConfiguration {
+
     @Bean
-    public RocketMQMessageListenerContainerRegistrar rocketMQMessageListenerContainerRegistrar(RocketMQMessageConverter rocketMQMessageConverter, ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties, RocketMQMessageHandler rocketMQMessageHandler) {
-        return new RocketMQMessageListenerContainerRegistrar(rocketMQMessageConverter, environment, rocketMQProperties, rocketMQMessageHandler);
+    public RocketMQMessagePostProcessor createMessagePostProcessor() {
+        return new RocketMQMessagePostProcessor();
     }
+
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQAutoConfiguration.java
@@ -25,6 +25,7 @@ import org.apache.rocketmq.spring.annotation.MessageModel;
 import org.apache.rocketmq.spring.annotation.SelectorType;
 import org.apache.rocketmq.spring.core.RocketMQTemplate;
 import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
+import org.apache.rocketmq.spring.support.RocketMQMessagePostProcessor;
 import org.apache.rocketmq.spring.support.RocketMQUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,9 +52,10 @@ import org.springframework.util.StringUtils;
 @EnableConfigurationProperties(RocketMQProperties.class)
 @ConditionalOnClass({MQAdmin.class})
 @ConditionalOnProperty(prefix = "rocketmq", value = "name-server", matchIfMissing = true)
-@Import({MessageConverterConfiguration.class, ListenerContainerConfiguration.class, ExtProducerResetConfiguration.class,
-        ExtConsumerResetConfiguration.class, RocketMQTransactionConfiguration.class, RocketMQListenerConfiguration.class})
-@AutoConfigureAfter({MessageConverterConfiguration.class})
+@Import({MessageConverterConfiguration.class, RocketMQMessageHandlerConfiguration.class, ListenerContainerConfiguration.class, ExtProducerResetConfiguration.class,
+        ExtConsumerResetConfiguration.class, RocketMQTransactionConfiguration.class, RocketMQListenerConfiguration.class,
+        MessagePostProcessorConfiguration.class})
+@AutoConfigureAfter({MessageConverterConfiguration.class, MessagePostProcessorConfiguration.class, RocketMQMessageHandlerConfiguration.class})
 @AutoConfigureBefore({RocketMQTransactionConfiguration.class})
 public class RocketMQAutoConfiguration implements ApplicationContextAware {
     private static final Logger log = LoggerFactory.getLogger(RocketMQAutoConfiguration.class);
@@ -166,7 +168,8 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
     @Bean(destroyMethod = "destroy")
     @Conditional(ProducerOrConsumerPropertyCondition.class)
     @ConditionalOnMissingBean(name = ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME)
-    public RocketMQTemplate rocketMQTemplate(RocketMQMessageConverter rocketMQMessageConverter) {
+    public RocketMQTemplate rocketMQTemplate(RocketMQMessageConverter rocketMQMessageConverter,
+                                             RocketMQMessagePostProcessor rocketMQMessagePostProcessor) {
         RocketMQTemplate rocketMQTemplate = new RocketMQTemplate();
         if (applicationContext.containsBean(PRODUCER_BEAN_NAME)) {
             rocketMQTemplate.setProducer((DefaultMQProducer) applicationContext.getBean(PRODUCER_BEAN_NAME));
@@ -175,6 +178,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
             rocketMQTemplate.setConsumer((DefaultLitePullConsumer) applicationContext.getBean(CONSUMER_BEAN_NAME));
         }
         rocketMQTemplate.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
+        rocketMQTemplate.setMessagePostProcessor(rocketMQMessagePostProcessor.getMessagePostProcessor());
         return rocketMQTemplate;
     }
 

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQMessageHandlerConfiguration.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/autoconfigure/RocketMQMessageHandlerConfiguration.java
@@ -19,17 +19,20 @@ package org.apache.rocketmq.spring.autoconfigure;
 
 import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
 import org.apache.rocketmq.spring.support.RocketMQMessageHandler;
-import org.apache.rocketmq.spring.support.RocketMQMessageListenerContainerRegistrar;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.ConfigurableEnvironment;
 
+/**
+ * @see RocketMQMessageConverter
+ */
 @Configuration
-@ConditionalOnMissingBean(RocketMQMessageListenerContainerRegistrar.class)
-public class ListenerContainerConfiguration {
+@ConditionalOnMissingBean(RocketMQMessageHandler.class)
+class RocketMQMessageHandlerConfiguration {
+
     @Bean
-    public RocketMQMessageListenerContainerRegistrar rocketMQMessageListenerContainerRegistrar(RocketMQMessageConverter rocketMQMessageConverter, ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties, RocketMQMessageHandler rocketMQMessageHandler) {
-        return new RocketMQMessageListenerContainerRegistrar(rocketMQMessageConverter, environment, rocketMQProperties, rocketMQMessageHandler);
+    public RocketMQMessageHandler createRocketMQMessageHandler() {
+        return (message, consumer) -> consumer.doHandler(message);
     }
+
 }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/core/RocketMQTemplate.java
@@ -72,6 +72,8 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
 
     private RocketMQMessageConverter rocketMQMessageConverter = new RocketMQMessageConverter();
 
+    private MessagePostProcessor messagePostProcessor;
+
     public DefaultMQProducer getProducer() {
         return producer;
     }
@@ -102,6 +104,14 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
 
     public void setMessageQueueSelector(MessageQueueSelector messageQueueSelector) {
         this.messageQueueSelector = messageQueueSelector;
+    }
+
+    public MessagePostProcessor getMessagePostProcessor() {
+        return messagePostProcessor;
+    }
+
+    public void setMessagePostProcessor(MessagePostProcessor messagePostProcessor) {
+        this.messagePostProcessor = messagePostProcessor;
     }
 
     public void setAsyncSenderExecutor(ExecutorService asyncSenderExecutor) {
@@ -1191,7 +1201,7 @@ public class RocketMQTemplate extends AbstractMessageSendingTemplate<String> imp
 
     private org.apache.rocketmq.common.message.Message createRocketMqMessage(
         String destination, Message<?> message) {
-        Message<?> msg = this.doConvert(message.getPayload(), message.getHeaders(), null);
+        Message<?> msg = this.doConvert(message.getPayload(), message.getHeaders(), messagePostProcessor);
         return RocketMQUtil.convertToRocketMessage(getMessageConverter(), charset,
             destination, msg);
     }

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageHandler.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageHandler.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+
+
+import org.apache.rocketmq.common.message.MessageExt;
+
+public interface RocketMQMessageHandler {
+
+    void doHandler(MessageExt message, RocketMQMessageHandlerChain chain) throws Exception;
+
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageHandlerChain.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageHandlerChain.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+
+import org.apache.rocketmq.common.message.MessageExt;
+
+public interface RocketMQMessageHandlerChain {
+    void doHandler(MessageExt message) throws Exception;
+}

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageListenerContainerRegistrar.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessageListenerContainerRegistrar.java
@@ -56,11 +56,15 @@ public class RocketMQMessageListenerContainerRegistrar implements ApplicationCon
 
     private final List<DefaultRocketMQListenerContainer> containers = new ArrayList<>();
 
+    private final RocketMQMessageHandler rocketMQMessageHandler;
+
     public RocketMQMessageListenerContainerRegistrar(RocketMQMessageConverter rocketMQMessageConverter,
-                                                     ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties) {
+                                                     ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties,
+                                                     RocketMQMessageHandler rocketMQMessageHandler) {
         this.rocketMQMessageConverter = rocketMQMessageConverter;
         this.environment = environment;
         this.rocketMQProperties = rocketMQProperties;
+        this.rocketMQMessageHandler = rocketMQMessageHandler;
     }
 
     @Override
@@ -146,6 +150,7 @@ public class RocketMQMessageListenerContainerRegistrar implements ApplicationCon
             container.setRocketMQReplyListener((RocketMQReplyListener) bean);
         }
         container.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
+        container.setRocketMQMessageHandler(rocketMQMessageHandler);
         container.setName(name);
 
         String namespace = environment.resolvePlaceholders(annotation.namespace());

--- a/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessagePostProcessor.java
+++ b/rocketmq-spring-boot/src/main/java/org/apache/rocketmq/spring/support/RocketMQMessagePostProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+
+import org.springframework.messaging.core.MessagePostProcessor;
+
+/**
+ * @see MessagePostProcessor
+ */
+public class RocketMQMessagePostProcessor {
+
+    public MessagePostProcessor getMessagePostProcessor() {
+        return null;
+    }
+
+}

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/RocketMQMessageHandlerTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/RocketMQMessageHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.spring.core.RocketMQListener;
+import org.junit.Test;
+import org.springframework.beans.BeansException;
+import org.springframework.context.support.GenericApplicationContext;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RocketMQMessageHandlerTest {
+
+    @Test
+    public void testRocketMQMessageHandler() throws Exception {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+
+        listenerContainer.setApplicationContext(new GenericApplicationContext(){
+            @Override
+            public <T> T getBean(String name, Class<T> requiredType) throws BeansException {
+                return (T) listenerContainer;
+            }
+        });
+        listenerContainer.setRocketMQMessageHandler(new RocketMQMessageHandler() {
+            @Override
+            public void doHandler(MessageExt message, RocketMQMessageHandlerChain chain) throws Exception {
+                message.putUserProperty("test", "test");
+                chain.doHandler(message);
+            }
+        });
+
+        listenerContainer.setRocketMQListener(new RocketMQListener<MessageExt>() {
+            @Override
+            public void onMessage(MessageExt message) {
+                assertEquals(message.getProperties().get("test"), "test");
+            }
+        });
+
+        Field messageTypeField = DefaultRocketMQListenerContainer.class.getDeclaredField("messageType");
+        messageTypeField.setAccessible(true);
+        messageTypeField.set(listenerContainer,MessageExt.class);
+
+        DefaultRocketMQListenerContainer.DefaultMessageListenerConcurrently concurrently =  listenerContainer.new DefaultMessageListenerConcurrently();
+        MessageExt messageExt = new MessageExt();
+        messageExt.getProperties();
+        concurrently.consumeMessage(Arrays.asList(messageExt),null);
+    }
+
+    @Test
+    public void testRocketMQMessageHandler1() throws Exception {
+        DefaultRocketMQListenerContainer listenerContainer = new DefaultRocketMQListenerContainer();
+
+        listenerContainer.setApplicationContext(new GenericApplicationContext(){
+            @Override
+            public <T> T getBean(String name, Class<T> requiredType) throws BeansException {
+                return (T) listenerContainer;
+            }
+        });
+        listenerContainer.setRocketMQMessageHandler(new RocketMQMessageHandler() {
+            @Override
+            public void doHandler(MessageExt message, RocketMQMessageHandlerChain chain) throws Exception {
+                message.putUserProperty("test", "test");
+                chain.doHandler(message);
+            }
+        });
+
+        listenerContainer.setRocketMQListener(new RocketMQListener<MessageExt>() {
+            @Override
+            public void onMessage(MessageExt message) {
+                assertEquals(message.getProperties().get("test"), "test");
+            }
+        });
+
+        Field messageTypeField = DefaultRocketMQListenerContainer.class.getDeclaredField("messageType");
+        messageTypeField.setAccessible(true);
+        messageTypeField.set(listenerContainer,MessageExt.class);
+
+        DefaultRocketMQListenerContainer.DefaultMessageListenerOrderly concurrently =  listenerContainer.new DefaultMessageListenerOrderly();
+        MessageExt messageExt = new MessageExt();
+        messageExt.getProperties();
+        concurrently.consumeMessage(Arrays.asList(messageExt),null);
+    }
+
+}

--- a/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/RocketMQMessagePostProcessorTest.java
+++ b/rocketmq-spring-boot/src/test/java/org/apache/rocketmq/spring/support/RocketMQMessagePostProcessorTest.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.spring.support;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.client.producer.SendStatus;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+import org.apache.rocketmq.spring.core.RocketMQTemplate;
+import org.junit.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.core.MessagePostProcessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.Objects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class RocketMQMessagePostProcessorTest {
+
+    @Test
+    public void testMessagePostProcessor() {
+
+        RocketMQTemplate rocketMQTemplate = new RocketMQTemplate();
+        rocketMQTemplate.setProducer(new DefaultMQProducer());
+        rocketMQTemplate.setMessagePostProcessor(new MessagePostProcessor() {
+            @Override
+            public Message<?> postProcessMessage(Message<?> message) {
+                throw new RuntimeException("postProcessMessage");
+            }
+        });
+        try {
+            rocketMQTemplate.syncSend("test", "payload");
+        } catch (MessagingException e) {
+            assertThat(e).hasMessageContaining("postProcessMessage");
+        }
+    }
+
+    @Test
+    public void testMessagePostProcessor2() {
+
+        RocketMQTemplate rocketMQTemplate = new RocketMQTemplate();
+        rocketMQTemplate.setProducer(new DefaultMQProducer() {
+            @Override
+            public SendResult send(org.apache.rocketmq.common.message.Message msg, long timeout) throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
+                SendResult sendResult = new SendResult();
+                if (Objects.equals(msg.getProperties().get("test"), "test")) {
+                    sendResult.setSendStatus(SendStatus.SEND_OK);
+                } else {
+                    sendResult.setSendStatus(SendStatus.FLUSH_DISK_TIMEOUT);
+                }
+                return sendResult;
+            }
+        });
+        rocketMQTemplate.setMessagePostProcessor(new MessagePostProcessor() {
+            @Override
+            public Message<?> postProcessMessage(Message<?> message) {
+                MessageBuilder<?> builder = MessageBuilder.fromMessage(message);
+                builder.setHeader("test", "test");
+                return builder.build();
+            }
+        });
+        SendResult sendResult = rocketMQTemplate.syncSend("test", "payload");
+        assertEquals(SendStatus.SEND_OK, sendResult.getSendStatus());
+    }
+}

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/ExtTemplateResetConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/ExtTemplateResetConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.rocketmq.client.autoconfigure;
 
 import org.apache.rocketmq.client.annotation.ExtProducerResetConfiguration;
 import org.apache.rocketmq.client.support.RocketMQMessageConverter;
+import org.apache.rocketmq.client.support.RocketMQMessagePostProcessor;
 import org.apache.rocketmq.client.support.RocketMQUtil;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientServiceProvider;
@@ -54,11 +55,15 @@ public class ExtTemplateResetConfiguration implements ApplicationContextAware, S
 
     private RocketMQMessageConverter rocketMQMessageConverter;
 
+    private RocketMQMessagePostProcessor rocketMQMessagePostProcessor;
+
     public ExtTemplateResetConfiguration(RocketMQMessageConverter rocketMQMessageConverter,
+                                         RocketMQMessagePostProcessor rocketMQMessagePostProcessor,
                                          ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties) {
         this.rocketMQMessageConverter = rocketMQMessageConverter;
         this.environment = environment;
         this.rocketMQProperties = rocketMQProperties;
+        this.rocketMQMessagePostProcessor = rocketMQMessagePostProcessor;
     }
 
     @Override
@@ -90,6 +95,7 @@ public class ExtTemplateResetConfiguration implements ApplicationContextAware, S
         RocketMQClientTemplate rocketMQTemplate = (RocketMQClientTemplate) bean;
         rocketMQTemplate.setProducerBuilder(producerBuilder);
         rocketMQTemplate.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
+        rocketMQTemplate.setMessagePostProcessor(rocketMQMessagePostProcessor.getMessagePostProcessor());
         String topic = environment.resolvePlaceholders(annotation.topic());
         log.info("Set real producer to {} using topic {}", beanName, topic);
     }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/MessagePostProcessorConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/MessagePostProcessorConfiguration.java
@@ -14,22 +14,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package org.apache.rocketmq.client.autoconfigure;
 
-package org.apache.rocketmq.spring.autoconfigure;
 
-import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
-import org.apache.rocketmq.spring.support.RocketMQMessageHandler;
-import org.apache.rocketmq.spring.support.RocketMQMessageListenerContainerRegistrar;
+import org.apache.rocketmq.client.support.RocketMQMessagePostProcessor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.ConfigurableEnvironment;
 
+/**
+ * @see RocketMQMessagePostProcessor
+ */
 @Configuration
-@ConditionalOnMissingBean(RocketMQMessageListenerContainerRegistrar.class)
-public class ListenerContainerConfiguration {
+@ConditionalOnMissingBean(RocketMQMessagePostProcessor.class)
+class MessagePostProcessorConfiguration {
+
     @Bean
-    public RocketMQMessageListenerContainerRegistrar rocketMQMessageListenerContainerRegistrar(RocketMQMessageConverter rocketMQMessageConverter, ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties, RocketMQMessageHandler rocketMQMessageHandler) {
-        return new RocketMQMessageListenerContainerRegistrar(rocketMQMessageConverter, environment, rocketMQProperties, rocketMQMessageHandler);
+    public RocketMQMessagePostProcessor createMessagePostProcessor() {
+        return new RocketMQMessagePostProcessor();
     }
+
 }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQAutoConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQAutoConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.rocketmq.client.autoconfigure;
 
 import org.apache.rocketmq.client.support.RocketMQMessageConverter;
+import org.apache.rocketmq.client.support.RocketMQMessagePostProcessor;
 import org.apache.rocketmq.client.support.RocketMQUtil;
 import org.apache.rocketmq.client.apis.ClientConfiguration;
 import org.apache.rocketmq.client.apis.ClientServiceProvider;
@@ -50,9 +51,10 @@ import java.util.Objects;
 
 @Configuration
 @EnableConfigurationProperties(RocketMQProperties.class)
-@Import({MessageConverterConfiguration.class, ListenerContainerConfiguration.class, ExtTemplateResetConfiguration.class,
-        ExtConsumerResetConfiguration.class, RocketMQTransactionConfiguration.class, RocketMQListenerConfiguration.class})
-@AutoConfigureAfter({MessageConverterConfiguration.class})
+@Import({MessageConverterConfiguration.class, RocketMQMessageHandlerConfiguration.class, ListenerContainerConfiguration.class, ExtTemplateResetConfiguration.class,
+        ExtConsumerResetConfiguration.class, RocketMQTransactionConfiguration.class, RocketMQListenerConfiguration.class,
+        MessagePostProcessorConfiguration.class})
+@AutoConfigureAfter({MessageConverterConfiguration.class, MessagePostProcessorConfiguration.class,RocketMQMessageHandlerConfiguration.class})
 @AutoConfigureBefore({RocketMQTransactionConfiguration.class})
 public class RocketMQAutoConfiguration implements ApplicationContextAware {
     private static final Logger log = LoggerFactory.getLogger(RocketMQAutoConfiguration.class);
@@ -126,7 +128,8 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
     @Bean(destroyMethod = "destroy")
     @Conditional(ProducerOrConsumerPropertyCondition.class)
     @ConditionalOnMissingBean(name = ROCKETMQ_TEMPLATE_DEFAULT_GLOBAL_NAME)
-    public RocketMQClientTemplate rocketMQClientTemplate(RocketMQMessageConverter rocketMQMessageConverter) {
+    public RocketMQClientTemplate rocketMQClientTemplate(RocketMQMessageConverter rocketMQMessageConverter,
+                                                         RocketMQMessagePostProcessor rocketMQMessagePostProcessor) {
         RocketMQClientTemplate rocketMQClientTemplate = new RocketMQClientTemplate();
 
         if (applicationContext.containsBean(PRODUCER_BUILDER_BEAN_NAME)) {
@@ -136,6 +139,7 @@ public class RocketMQAutoConfiguration implements ApplicationContextAware {
             rocketMQClientTemplate.setSimpleConsumerBuilder((SimpleConsumerBuilder) applicationContext.getBean(SIMPLE_CONSUMER_BUILDER_BEAN_NAME));
         }
         rocketMQClientTemplate.setMessageConverter(rocketMQMessageConverter.getMessageConverter());
+        rocketMQClientTemplate.setMessagePostProcessor(rocketMQMessagePostProcessor.getMessagePostProcessor());
         return rocketMQClientTemplate;
     }
 

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQMessageHandlerConfiguration.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/autoconfigure/RocketMQMessageHandlerConfiguration.java
@@ -15,21 +15,20 @@
  * limitations under the License.
  */
 
-package org.apache.rocketmq.spring.autoconfigure;
+package org.apache.rocketmq.client.autoconfigure;
 
-import org.apache.rocketmq.spring.support.RocketMQMessageConverter;
-import org.apache.rocketmq.spring.support.RocketMQMessageHandler;
-import org.apache.rocketmq.spring.support.RocketMQMessageListenerContainerRegistrar;
+import org.apache.rocketmq.client.support.RocketMQMessageHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.ConfigurableEnvironment;
 
 @Configuration
-@ConditionalOnMissingBean(RocketMQMessageListenerContainerRegistrar.class)
-public class ListenerContainerConfiguration {
+@ConditionalOnMissingBean(RocketMQMessageHandler.class)
+class RocketMQMessageHandlerConfiguration {
+
     @Bean
-    public RocketMQMessageListenerContainerRegistrar rocketMQMessageListenerContainerRegistrar(RocketMQMessageConverter rocketMQMessageConverter, ConfigurableEnvironment environment, RocketMQProperties rocketMQProperties, RocketMQMessageHandler rocketMQMessageHandler) {
-        return new RocketMQMessageListenerContainerRegistrar(rocketMQMessageConverter, environment, rocketMQProperties, rocketMQMessageHandler);
+    public RocketMQMessageHandler createRocketMQMessageHandler() {
+        return (message, consumer) -> consumer.doHandler(message);
     }
+
 }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/core/RocketMQClientTemplate.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/core/RocketMQClientTemplate.java
@@ -33,6 +33,7 @@ import org.springframework.beans.factory.DisposableBean;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessagingException;
 import org.springframework.messaging.core.AbstractMessageSendingTemplate;
+import org.springframework.messaging.core.MessagePostProcessor;
 import org.springframework.messaging.support.MessageBuilder;
 
 import java.io.IOException;
@@ -58,6 +59,8 @@ public class RocketMQClientTemplate extends AbstractMessageSendingTemplate<Strin
     private RocketMQMessageConverter rocketMQMessageConverter = new RocketMQMessageConverter();
 
     private String charset = "UTF-8";
+
+    private MessagePostProcessor messagePostProcessor;
 
     public Producer getProducer() {
         if (Objects.isNull(producer)) {
@@ -130,6 +133,13 @@ public class RocketMQClientTemplate extends AbstractMessageSendingTemplate<Strin
         this.charset = charset;
     }
 
+    public MessagePostProcessor getMessagePostProcessor() {
+        return messagePostProcessor;
+    }
+
+    public void setMessagePostProcessor(MessagePostProcessor messagePostProcessor) {
+        this.messagePostProcessor = messagePostProcessor;
+    }
 
     @Override
     public void destroy() throws Exception {
@@ -391,7 +401,7 @@ public class RocketMQClientTemplate extends AbstractMessageSendingTemplate<Strin
 
 
     private org.apache.rocketmq.client.apis.message.Message createRocketMQMessage(String destination, Message<?> message, Duration messageDelayTime, String messageGroup) {
-        Message<?> msg = this.doConvert(message.getPayload(), message.getHeaders(), null);
+        Message<?> msg = this.doConvert(message.getPayload(), message.getHeaders(), messagePostProcessor);
         return RocketMQUtil.convertToClientMessage(getMessageConverter(), charset,
                 destination, msg, messageDelayTime, messageGroup);
     }

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessageHandler.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessageHandler.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.support;
+
+
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+public interface RocketMQMessageHandler {
+
+    ConsumeResult doHandler(MessageView message, RocketMQMessageHandlerChain consumer);
+
+}

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessageHandlerChain.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessageHandlerChain.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.support;
+
+import org.apache.rocketmq.client.apis.consumer.ConsumeResult;
+import org.apache.rocketmq.client.apis.message.MessageView;
+
+public interface RocketMQMessageHandlerChain {
+    ConsumeResult doHandler(MessageView message);
+}

--- a/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessagePostProcessor.java
+++ b/rocketmq-v5-client-spring-boot/src/main/java/org/apache/rocketmq/client/support/RocketMQMessagePostProcessor.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.rocketmq.client.support;
+
+import org.springframework.messaging.core.MessagePostProcessor;
+
+/**
+ * @see MessagePostProcessor
+ */
+public class RocketMQMessagePostProcessor {
+
+    public MessagePostProcessor getMessagePostProcessor() {
+        return null;
+    }
+
+}


### PR DESCRIPTION
https://github.com/apache/rocketmq-spring/issues/583

## What is the purpose of the change

- 新增 RocketMQMessageHandler 用户处理消息前预处理,可用于处理链路追踪
- 新增 RocketMQMessagePostProcessor 类，用于处理消息发送前预处理消息,用来传递链路ID
